### PR TITLE
Fix php-parser dependency temporarily

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ovr/phpreflection": "~0.2.5",
         "symfony/console": "~2.7.0",
         "symfony/event-dispatcher": "~2.7.5",
-        "nikic/php-parser": "~2.0.0"
+        "nikic/php-parser": "~2.0.0beta1"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8",


### PR DESCRIPTION
Right now php-parser is in 2.0.0beta1, so a version selector of 2.0.0 won't work. I've tried `composer global require ovr/phpsa dev-master@dev`.