### PR TITLE
Fix constant existence check

### DIFF
--- a/src/Compiler/Expression.php
+++ b/src/Compiler/Expression.php
@@ -184,7 +184,7 @@ class Expression
                 $this->context
             )
         );
-        
+
         $className = get_class($expr);
         switch ($className) {
             case Node\Arg::class:
@@ -348,7 +348,7 @@ class Expression
     public function getFullyQualifiedNodeName(Node\Name\FullyQualified $expr)
     {
         $this->context->debug('Unimplemented FullyQualified', $expr);
-        
+
         return new CompiledExpression;
     }
 
@@ -564,7 +564,7 @@ class Expression
         if ($leftCE->isObject()) {
             $leftCEValue = $leftCE->getValue();
             if ($leftCEValue instanceof ClassDefinition) {
-                if (!$leftCEValue->hasConst($expr->name)) {
+                if (!$leftCEValue->hasConst($expr->name, true)) {
                     $this->context->notice(
                         'undefined-const',
                         sprintf('Constant %s does not exist in %s scope', $expr->name, $expr->class),

--- a/src/Definition/ClassDefinition.php
+++ b/src/Definition/ClassDefinition.php
@@ -169,7 +169,7 @@ class ClassDefinition extends ParentDefinition
      */
     public function hasConst($name, $inherit = false)
     {
-        if ($inherit && $this->extendsClassDefinition && $this->extendsClassDefinition->hasConst($name)) {
+        if ($inherit && $this->extendsClassDefinition && $this->extendsClassDefinition->hasConst($name, $inherit)) {
             return true;
         }
 

--- a/src/Definition/ClassDefinition.php
+++ b/src/Definition/ClassDefinition.php
@@ -163,11 +163,16 @@ class ClassDefinition extends ParentDefinition
     }
 
     /**
-     * @param $name
+     * @param string $name
+     * @param bool $inherit
      * @return bool
      */
-    public function hasConst($name)
+    public function hasConst($name, $inherit = false)
     {
+        if ($inherit && $this->extendsClassDefinition && $this->extendsClassDefinition->hasConst($name)) {
+            return true;
+        }
+
         return isset($this->constants[$name]);
     }
 

--- a/src/Definition/RuntimeClassDefinition.php
+++ b/src/Definition/RuntimeClassDefinition.php
@@ -54,10 +54,13 @@ class RuntimeClassDefinition extends ClassDefinition
             return false;
         }
 
+        // NOTE: ReflectionClass::hasConstant also checks parent classes, so if $inherit is true, the job is already done.
         if ($inherit) {
             return true;
         }
 
+        // but if it's not, we need to make sure that the constant is defined only in the current class. It means that
+        // we have to check that it has no parent or that the parent does not define the constant.
         $parent = $this->reflection->getParentClass();
         if (!$parent) {
             return true;

--- a/src/Definition/RuntimeClassDefinition.php
+++ b/src/Definition/RuntimeClassDefinition.php
@@ -44,12 +44,23 @@ class RuntimeClassDefinition extends ClassDefinition
     }
 
     /**
-     * @param $name
+     * @param string $name
+     * @param bool $inherit
      * @return bool
      */
-    public function hasConst($name)
+    public function hasConst($name, $inherit = false)
     {
-        return $this->reflection->hasConstant($name);
+        if (!$this->reflection->hasConstant($name)) {
+            return false;
+        }
+
+        if ($inherit) {
+            return true;
+        }
+
+        $parent = $this->reflection->getParentClass();
+
+        return !$parent->hasConstant($name);
     }
 
     /**

--- a/src/Definition/RuntimeClassDefinition.php
+++ b/src/Definition/RuntimeClassDefinition.php
@@ -59,6 +59,9 @@ class RuntimeClassDefinition extends ClassDefinition
         }
 
         $parent = $this->reflection->getParentClass();
+        if (!$parent) {
+            return true;
+        }
 
         return !$parent->hasConstant($name);
     }
@@ -104,7 +107,13 @@ class RuntimeClassDefinition extends ClassDefinition
      */
     public function getExtendsClassDefinition()
     {
-        throw new NotImplementedException(__FUNCTION__);
+        $parentReflection = $this->reflection->getParentClass();
+
+        if (!$parentReflection) {
+            return null;
+        }
+
+        return new static($parentReflection);
     }
 
     /**
@@ -112,6 +121,12 @@ class RuntimeClassDefinition extends ClassDefinition
      */
     public function getExtendsClass()
     {
-        throw new NotImplementedException(__FUNCTION__);
+        $parentReflection = $this->reflection->getParentClass();
+
+        if (!$parentReflection) {
+            return null;
+        }
+
+        return $parentReflection->getName();
     }
 }

--- a/tests/PHPSA/Defintion/ClassDefintionTest.php
+++ b/tests/PHPSA/Defintion/ClassDefintionTest.php
@@ -2,6 +2,9 @@
 
 namespace Tests\PHPSA\Defintion;
 
+use PhpParser\Node\Const_;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\ClassConst;
 use PHPSA\Definition\ClassDefinition;
 use Tests\PHPSA\TestCase;
 
@@ -97,5 +100,35 @@ class ClassDefintionTest extends TestCase
         $this->assertSame($methodName, $method->getName());
 
         return $classDefinition;
+    }
+
+    public function testHasConstWithNoParent()
+    {
+        $classDefinition = $this->getSimpleInstance();
+        $classDefinition->addConst(new ClassConst([
+            new Const_('FOO', new String_('bar'))
+        ]));
+
+        $this->assertTrue($classDefinition->hasConst('FOO'));
+        $this->assertFalse($classDefinition->hasConst('BAR'));
+    }
+
+    public function testHasConstWithParent()
+    {
+        $parentClassDefinition = $this->getSimpleInstance();
+        $classDefinition = $this->getSimpleInstance();
+
+        $parentClassDefinition->addConst(new ClassConst([
+            new Const_('BAR', new String_('baz'))
+        ]));
+
+        $classDefinition->setExtendsClassDefinition($parentClassDefinition);
+        $classDefinition->addConst(new ClassConst([
+            new Const_('FOO', new String_('bar'))
+        ]));
+
+        $this->assertTrue($classDefinition->hasConst('FOO'));
+        $this->assertFalse($classDefinition->hasConst('BAR'));
+        $this->assertTrue($classDefinition->hasConst('BAR', true));
     }
 }

--- a/tests/PHPSA/Defintion/RuntimeClassDefintionTest.php
+++ b/tests/PHPSA/Defintion/RuntimeClassDefintionTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\PHPSA\Defintion;
 
+use PHPSA\Compiler\Parameter;
 use PHPSA\Definition\RuntimeClassDefinition;
+use PHPSA\Variable;
 use ReflectionClass;
 use Tests\PHPSA\TestCase;
 
@@ -38,6 +40,15 @@ class RuntimeClassDefintionTest extends TestCase
         }
 
         static::assertFalse($definition->hasConst('XXXXXXXXX'));
+    }
+
+    public function testHasConstWithParent()
+    {
+        $reflection = new ReflectionClass(Parameter::class);
+        $definition = new RuntimeClassDefinition($reflection);
+
+        static::assertFalse($definition->hasConst('BRANCH_ROOT'));
+        static::assertTrue($definition->hasConst('BRANCH_ROOT', true));
     }
 
     public function testHasProperty()


### PR DESCRIPTION
Class constant existence check failed when the constant was defined in the parent class. This caused incorrect notices to be shown to the user.