### PR TITLE
Fix properties definition

### DIFF
--- a/src/Definition/ClassDefinition.php
+++ b/src/Definition/ClassDefinition.php
@@ -87,7 +87,9 @@ class ClassDefinition extends ParentDefinition
      */
     public function addProperty(Node\Stmt\Property $property)
     {
-        $this->properties[$property->props[0]->name] = $property;
+        foreach ($property->props as $propertyDefinition) {
+            $this->properties[$propertyDefinition->name] = $propertyDefinition;
+        }
     }
 
     /**

--- a/tests/PHPSA/Defintion/ClassDefintionTest.php
+++ b/tests/PHPSA/Defintion/ClassDefintionTest.php
@@ -68,6 +68,21 @@ class ClassDefintionTest extends TestCase
 
         $this->assertTrue($classDefinition->hasProperty('test1'));
         $this->assertTrue($classDefinition->hasProperty('test2'));
+
+        $property = new \PhpParser\Node\Stmt\Property(0, [
+            new \PhpParser\Node\Stmt\PropertyProperty(
+                'foo',
+                new \PhpParser\Node\Scalar\String_('test string')
+            ),
+            new \PhpParser\Node\Stmt\PropertyProperty(
+                'bar',
+                new \PhpParser\Node\Scalar\String_('test string')
+            )
+        ]);
+        $classDefinition->addProperty($property);
+
+        $this->assertTrue($classDefinition->hasProperty('foo'));
+        $this->assertTrue($classDefinition->hasProperty('bar'));
     }
 
     public function testMethodSetGet()


### PR DESCRIPTION
Properties defined in a single statement were not parsed:

```php
class Foo {
    private $first, $second;
}
```

Only `$first` was detected.