### PR TITLE
scrutinizer exclude analyzer fixtures

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -32,4 +32,5 @@ tools:
         enabled: true
         filter:
             paths: ["src/*", "tests/*"]
+            excluded_paths: ["tests/analyze-fixtures/*"]
     sensiolabs_security_checker: true


### PR DESCRIPTION
there are only examples of "bad" code in there so we can exclude it