### PR TITLE
Add some tests and support more types for logic operators

### DIFF
--- a/src/Compiler/Expression/Operators/Logical/BooleanAnd.php
+++ b/src/Compiler/Expression/Operators/Logical/BooleanAnd.php
@@ -31,6 +31,7 @@ class BooleanAnd extends AbstractExpressionCompiler
             case CompiledExpression::NULL:
             case CompiledExpression::ARR:
             case CompiledExpression::OBJECT:
+            case CompiledExpression::NUMBER:
                 switch ($right->getType()) {
                     case CompiledExpression::INTEGER:
                     case CompiledExpression::DOUBLE:
@@ -39,6 +40,7 @@ class BooleanAnd extends AbstractExpressionCompiler
                     case CompiledExpression::NULL:
                     case CompiledExpression::ARR:
                     case CompiledExpression::OBJECT:
+                    case CompiledExpression::NUMBER:
                         return CompiledExpression::fromZvalValue($left->getValue() && $right->getValue());
                 }
                 break;

--- a/src/Compiler/Expression/Operators/Logical/BooleanAnd.php
+++ b/src/Compiler/Expression/Operators/Logical/BooleanAnd.php
@@ -29,12 +29,16 @@ class BooleanAnd extends AbstractExpressionCompiler
             case CompiledExpression::STRING:
             case CompiledExpression::BOOLEAN:
             case CompiledExpression::NULL:
+            case CompiledExpression::ARR:
+            case CompiledExpression::OBJECT:
                 switch ($right->getType()) {
                     case CompiledExpression::INTEGER:
                     case CompiledExpression::DOUBLE:
                     case CompiledExpression::STRING:
                     case CompiledExpression::BOOLEAN:
                     case CompiledExpression::NULL:
+                    case CompiledExpression::ARR:
+                    case CompiledExpression::OBJECT:
                         return CompiledExpression::fromZvalValue($left->getValue() && $right->getValue());
                 }
                 break;

--- a/src/Compiler/Expression/Operators/Logical/BooleanNot.php
+++ b/src/Compiler/Expression/Operators/Logical/BooleanNot.php
@@ -25,8 +25,13 @@ class BooleanNot extends AbstractExpressionCompiler
         switch ($compiledExpression->getType()) {
             case CompiledExpression::DOUBLE:
             case CompiledExpression::INTEGER:
+            case CompiledExpression::NUMBER:
             case CompiledExpression::STRING:
             case CompiledExpression::BOOLEAN:
+            case CompiledExpression::STRING:
+            case CompiledExpression::NULL:
+            case CompiledExpression::ARR:
+            case CompiledExpression::OBJECT:
                 return new CompiledExpression(CompiledExpression::BOOLEAN, !$compiledExpression->getValue());
         }
 

--- a/src/Compiler/Expression/Operators/Logical/BooleanNot.php
+++ b/src/Compiler/Expression/Operators/Logical/BooleanNot.php
@@ -28,7 +28,6 @@ class BooleanNot extends AbstractExpressionCompiler
             case CompiledExpression::NUMBER:
             case CompiledExpression::STRING:
             case CompiledExpression::BOOLEAN:
-            case CompiledExpression::STRING:
             case CompiledExpression::NULL:
             case CompiledExpression::ARR:
             case CompiledExpression::OBJECT:

--- a/src/Compiler/Expression/Operators/Logical/BooleanOr.php
+++ b/src/Compiler/Expression/Operators/Logical/BooleanOr.php
@@ -29,12 +29,16 @@ class BooleanOr extends AbstractExpressionCompiler
             case CompiledExpression::STRING:
             case CompiledExpression::BOOLEAN:
             case CompiledExpression::NULL:
+            case CompiledExpression::ARR:
+            case CompiledExpression::OBJECT:
                 switch ($right->getType()) {
                     case CompiledExpression::INTEGER:
                     case CompiledExpression::DOUBLE:
                     case CompiledExpression::STRING:
                     case CompiledExpression::BOOLEAN:
                     case CompiledExpression::NULL:
+                    case CompiledExpression::ARR:
+                    case CompiledExpression::OBJECT:
                         return CompiledExpression::fromZvalValue($left->getValue() || $right->getValue());
                 }
                 break;

--- a/src/Compiler/Expression/Operators/Logical/BooleanOr.php
+++ b/src/Compiler/Expression/Operators/Logical/BooleanOr.php
@@ -31,6 +31,7 @@ class BooleanOr extends AbstractExpressionCompiler
             case CompiledExpression::NULL:
             case CompiledExpression::ARR:
             case CompiledExpression::OBJECT:
+            case CompiledExpression::NUMBER:
                 switch ($right->getType()) {
                     case CompiledExpression::INTEGER:
                     case CompiledExpression::DOUBLE:
@@ -39,6 +40,7 @@ class BooleanOr extends AbstractExpressionCompiler
                     case CompiledExpression::NULL:
                     case CompiledExpression::ARR:
                     case CompiledExpression::OBJECT:
+                    case CompiledExpression::NUMBER:
                         return CompiledExpression::fromZvalValue($left->getValue() || $right->getValue());
                 }
                 break;

--- a/src/Variable.php
+++ b/src/Variable.php
@@ -260,6 +260,7 @@ class Variable
         return 'variable';
     }
 
+    //@codeCoverageIgnoreStart
     /**
      * @return array
      */
@@ -289,4 +290,5 @@ class Variable
             'symbol-type' => $this->getSymbolType()
         ];
     }
+    //@codeCoverageIgnoreEnd
 }

--- a/tests/PHPSA/CompiledExpressionTest.php
+++ b/tests/PHPSA/CompiledExpressionTest.php
@@ -142,4 +142,26 @@ class CompiledExpressionTest extends TestCase
         $compiledExpression = new CompiledExpression(CompiledExpression::NULL);
         $this->assertTrue($compiledExpression->hasValue());
     }
+
+    public function testCanBeObject()
+    {
+        // Mixed type can be object
+        $expr = new CompiledExpression(CompiledExpression::MIXED, null);
+        $this->assertSame(true, $expr->canBeObject());
+
+        // Integer type can't be object
+        $expr2 = new CompiledExpression(CompiledExpression::INTEGER, 1);
+        $this->assertSame(false, $expr2->canBeObject());
+    }
+
+    public function testIsObject()
+    {
+        // Mixed type could be object but it's unclear
+        $expr = new CompiledExpression(CompiledExpression::MIXED, null);
+        $this->assertSame(false, $expr->isObject());
+
+        // Object type is object
+        $expr2 = new CompiledExpression(CompiledExpression::OBJECT, null);
+        $this->assertSame(true, $expr2->isObject());
+    }
 }

--- a/tests/PHPSA/CompiledExpressionTest.php
+++ b/tests/PHPSA/CompiledExpressionTest.php
@@ -147,21 +147,21 @@ class CompiledExpressionTest extends TestCase
     {
         // Mixed type can be object
         $expr = new CompiledExpression(CompiledExpression::MIXED, null);
-        $this->assertSame(true, $expr->canBeObject());
+        parent::assertTrue($expr->canBeObject());
 
         // Integer type can't be object
         $expr2 = new CompiledExpression(CompiledExpression::INTEGER, 1);
-        $this->assertSame(false, $expr2->canBeObject());
+        parent::assertFalse($expr2->canBeObject());
     }
 
     public function testIsObject()
     {
         // Mixed type could be object but it's unclear
         $expr = new CompiledExpression(CompiledExpression::MIXED, null);
-        $this->assertSame(false, $expr->isObject());
+        parent::assertFalse($expr->isObject());
 
         // Object type is object
         $expr2 = new CompiledExpression(CompiledExpression::OBJECT, null);
-        $this->assertSame(true, $expr2->isObject());
+        parent::assertTrue($expr2->isObject());
     }
 }

--- a/tests/PHPSA/Expression/Operators/Logical/BooleanAndTest.php
+++ b/tests/PHPSA/Expression/Operators/Logical/BooleanAndTest.php
@@ -18,6 +18,16 @@ class BooleanAndTest extends \Tests\PHPSA\TestCase
             array(false, true, false),
             array(true, false, false),
             array(false, false, false),
+            array(null, null, false),
+            array(true, null, false),
+            array(null, true, false),
+            array(1, true, true),
+            array(1.4, true, true),
+            array(1, false, false),
+            array(-1, true, true),
+            array("a", true, true),
+            array(array(), array(), false),
+            array(array(), "a", false),
         );
     }
 

--- a/tests/PHPSA/Expression/Operators/Logical/BooleanNotTest.php
+++ b/tests/PHPSA/Expression/Operators/Logical/BooleanNotTest.php
@@ -22,6 +22,10 @@ class BooleanNotTest extends \Tests\PHPSA\TestCase
             array(false, true),
             array(1, false),
             array(-1, false),
+            array(1.4, false),
+            array(null, true),
+            array("a", false),
+            array(array(), true),
         );
     }
 

--- a/tests/PHPSA/Expression/Operators/Logical/BooleanOrTest.php
+++ b/tests/PHPSA/Expression/Operators/Logical/BooleanOrTest.php
@@ -23,6 +23,13 @@ class BooleanOrTest extends \Tests\PHPSA\TestCase
             array(null, null, false),
             array(true, null, true),
             array(null, true, true),
+            array(1, true, true),
+            array(1.4, false, true),
+            array(1, false, true),
+            array(-1, false, true),
+            array("a", false, true),
+            array(array(), array(), false),
+            array(array(), "a", true),
         );
     }
 

--- a/tests/PHPSA/VariableTest.php
+++ b/tests/PHPSA/VariableTest.php
@@ -176,33 +176,33 @@ class VariableTest extends TestCase
     public function testGetTypeName()
     {
         $int = new Variable('a', 1, CompiledExpression::INTEGER);
-        static::assertSame("integer", $int->getTypeName());
+        parent::assertSame("integer", $int->getTypeName());
 
         $double = new Variable('b', 1, CompiledExpression::DOUBLE);
-        static::assertSame("double", $double->getTypeName());
+        parent::assertSame("double", $double->getTypeName());
 
         $number = new Variable('c', 1, CompiledExpression::NUMBER);
-        static::assertSame("number", $number->getTypeName());
+        parent::assertSame("number", $number->getTypeName());
 
         $arr = new Variable('d', [1,2], CompiledExpression::ARR);
-        static::assertSame("array", $arr->getTypeName());
+        parent::assertSame("array", $arr->getTypeName());
 
         $object = new Variable('e', 1, CompiledExpression::OBJECT);
-        static::assertSame("object", $object->getTypeName());
+        parent::assertSame("object", $object->getTypeName());
 
         $resource = new Variable('f', 1, CompiledExpression::RESOURCE);
-        static::assertSame("resource", $resource->getTypeName());
+        parent::assertSame("resource", $resource->getTypeName());
 
         $callable = new Variable('g', 1, CompiledExpression::CALLABLE_TYPE);
-        static::assertSame("callable", $callable->getTypeName());
+        parent::assertSame("callable", $callable->getTypeName());
 
         $boolean = new Variable('h', 1, CompiledExpression::BOOLEAN);
-        static::assertSame("boolean", $boolean->getTypeName());
+        parent::assertSame("boolean", $boolean->getTypeName());
 
         $null = new Variable('i', 1, CompiledExpression::NULL);
-        static::assertSame("null", $null->getTypeName());
+        parent::assertSame("null", $null->getTypeName());
 
         $unknown = new Variable('j', 1, CompiledExpression::UNKNOWN);
-        static::assertSame("unknown", $unknown->getTypeName());
+        parent::assertSame("unknown", $unknown->getTypeName());
     }
 }

--- a/tests/PHPSA/VariableTest.php
+++ b/tests/PHPSA/VariableTest.php
@@ -172,4 +172,37 @@ class VariableTest extends TestCase
         static::assertSame($variable->getValue(), $parentVariable->getValue());
         static::assertSame($variable->getType(), $parentVariable->getType());
     }
+
+    public function testGetTypeName()
+    {
+        $int = new Variable('a', 1, CompiledExpression::INTEGER);
+        static::assertSame("integer", $int->getTypeName());
+
+        $double = new Variable('b', 1, CompiledExpression::DOUBLE);
+        static::assertSame("double", $double->getTypeName());
+
+        $number = new Variable('c', 1, CompiledExpression::NUMBER);
+        static::assertSame("number", $number->getTypeName());
+
+        $arr = new Variable('d', [1,2], CompiledExpression::ARR);
+        static::assertSame("array", $arr->getTypeName());
+
+        $object = new Variable('e', 1, CompiledExpression::OBJECT);
+        static::assertSame("object", $object->getTypeName());
+
+        $resource = new Variable('f', 1, CompiledExpression::RESOURCE);
+        static::assertSame("resource", $resource->getTypeName());
+
+        $callable = new Variable('g', 1, CompiledExpression::CALLABLE_TYPE);
+        static::assertSame("callable", $callable->getTypeName());
+
+        $boolean = new Variable('h', 1, CompiledExpression::BOOLEAN);
+        static::assertSame("boolean", $boolean->getTypeName());
+
+        $null = new Variable('i', 1, CompiledExpression::NULL);
+        static::assertSame("null", $null->getTypeName());
+
+        $unknown = new Variable('j', 1, CompiledExpression::UNKNOWN);
+        static::assertSame("unknown", $unknown->getTypeName());
+    }
 }

--- a/tests/analyze-fixtures/Statement/UnexpectedUseOfThis.php
+++ b/tests/analyze-fixtures/Statement/UnexpectedUseOfThis.php
@@ -63,6 +63,67 @@ class UnexpectedUseOfThis
 
         return 'Fatal error: Cannot unset $this';
     }
+
+    /**
+     * @return string
+     */
+    public function OtherAsArgument($a)
+    {
+        return 'Ok';
+    }
+
+    /**
+     * @return string
+     */
+    public function OtherInCatch()
+    {
+        try {
+            throw new \LogicException();
+        } catch (\Exception $a) {
+            return 'Ok';
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function OtherAsLoopVariable()
+    {
+        foreach (['foo'] as $a) {
+            return 'Ok';
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function OtherAsStaticVariable()
+    {
+        static $a;
+
+        return 'Ok';
+    }
+
+    /**
+     * @return string
+     */
+    public function OtherAsGlobalVariable()
+    {
+        global $a;
+
+        return 'Ok';
+    }
+
+    /**
+     * @return string
+     */
+    public function unsetOther()
+    {
+        $a = 1;
+        unset($a);
+
+        return 'Ok';
+    }
 }
 ?>
 ----------------------------


### PR DESCRIPTION
So i added some missing tests and found that the logical operators compiler did not support all possible types (maybe callable and so on works too i didn't check that)