### PR TITLE
Use autoload-dev instead of a bootstrap file for phpunit.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,5 +35,10 @@
         "psr-4": {
             "PHPSA\\": "src/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\PHPSA\\": "tests/PHPSA"
+        }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,7 @@
          processIsolation="false"
          stopOnFailure="true"
          syntaxCheck="true"
-         bootstrap="./tests/PHPSA/Bootstrap.php"
+         bootstrap="./vendor/autoload.php"
         >
 
     <testsuites>

--- a/tests/PHPSA/Bootstrap.php
+++ b/tests/PHPSA/Bootstrap.php
@@ -1,6 +1,0 @@
-<?php
-
-include_once __DIR__ . '/../../vendor/autoload.php';
-include_once __DIR__ . '/TestCase.php';
-include_once __DIR__ . '/Expression/Operators/Comparison/BaseTestCase.php';
-include_once __DIR__ . '/Expression/Operators/Arithmetical/AbstractDivMod.php';


### PR DESCRIPTION
It's cleaner, automatically uses autoloading for classes instead of manually requiring files. If additional files needs to be required, specify them in the autoload-dev section (similar to how it's done in the autoload section).