### PR TITLE
Add an analyzer to tell users "Do not use goto statements".

### DIFF
--- a/src/Analyzer/Factory.php
+++ b/src/Analyzer/Factory.php
@@ -37,6 +37,7 @@ class Factory
         );
         $analyzer->registerStatementPasses(
             [
+                new AnalyzerPass\Statement\DoNotUseGoto(),
                 new AnalyzerPass\Statement\MissingBreakStatement(),
                 new AnalyzerPass\Statement\MethodCannotReturn(),
                 new AnalyzerPass\Statement\UnexpectedUseOfThis(),

--- a/src/Analyzer/Pass/Statement/DoNotUseGoto.php
+++ b/src/Analyzer/Pass/Statement/DoNotUseGoto.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace PHPSA\Analyzer\Pass\Statement;
+
+use PhpParser\Node\Stmt;
+use PhpParser\Node;
+use PHPSA\Analyzer\Pass;
+use PHPSA\Context;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+
+class DoNotUseGoto implements Pass\ConfigurablePassInterface, Pass\AnalyzerPassInterface
+{
+    /**
+     * @param Stmt\Goto_ $stmt
+     * @param Context $context
+     * @return bool
+     */
+    public function pass(Stmt\Goto_ $stmt, Context $context)
+    {
+        $context->notice('do_not_use_goto', 'Do not use goto statements', $stmt);
+
+        return true;
+    }
+
+    /**
+     * @return TreeBuilder
+     */
+    public function getConfiguration()
+    {
+        $treeBuilder = new TreeBuilder();
+        $treeBuilder->root('do_not_use_goto')
+            ->canBeDisabled()
+        ;
+
+        return $treeBuilder;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRegister()
+    {
+        return [
+            Stmt\Goto_::class,
+        ];
+    }
+}

--- a/tests/analyze-fixtures/DoNotUseGoto.php
+++ b/tests/analyze-fixtures/DoNotUseGoto.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Compiling\Statements;
+
+class DoNotUseGoto {
+    public function testGoto()
+    {
+        marker:
+        goto marker;
+    }
+
+    public function testNoGoto()
+    {
+
+    }
+}
+
+?>
+----------------------------
+[
+    {
+        "type": "do_not_use_goto",
+        "message": "Do not use goto statements",
+        "file": "DoNotUseGoto.php",
+        "line": 8
+    }
+]


### PR DESCRIPTION
Should take care of #117.

Couple comments based on my experience:
* There needs to be some documentation about naming convention for analyzers
* Make it easy to filter which analyze-fixtures to test in `\Tests\PHPSA\AnalyzeFixturesTest` (so that a user can selectively test a particular analyze-fixture)
* Possibly explain how analyze-fixtures are to be written (explicit the implicit rules)