### PR TITLE
Bool type

### DIFF
--- a/src/Compiler/Types.php
+++ b/src/Compiler/Types.php
@@ -55,7 +55,6 @@ class Types
         return self::getType(gettype($value));
     }
 
-
     /**
      * Get type (integer) by $type
      *
@@ -81,6 +80,7 @@ class Types
             case 'array':
                 return CompiledExpression::ARR;
             case 'boolean':
+            case 'bool':
                 return CompiledExpression::BOOLEAN;
             case 'NULL':
                 return CompiledExpression::NULL;

--- a/tests/PHPSA/Compiler/TypesTest.php
+++ b/tests/PHPSA/Compiler/TypesTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\PHPSA\Compiler;
+
+use PHPSA\CompiledExpression;
+use PHPSA\Compiler\Types;
+use Tests\PHPSA\TestCase;
+
+class TypesTest extends TestCase
+{
+    /**
+     * @dataProvider typesAsStringProvider
+     */
+    public function testGetType($typeAsString, $expectedType)
+    {
+        static::assertSame($expectedType, Types::getType($typeAsString));
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Type 'not a valid type' is not supported
+     */
+    public function testGetTypeWithAnUnknownTypeThrows()
+    {
+        Types::getType('not a valid type');
+    }
+
+    public function typesAsStringProvider()
+    {
+        return [
+            ['integer', CompiledExpression::INTEGER],
+            ['int', CompiledExpression::INTEGER],
+            ['double', CompiledExpression::DOUBLE],
+            ['string', CompiledExpression::STRING],
+            ['resource', CompiledExpression::RESOURCE],
+            ['callable', CompiledExpression::CALLABLE_TYPE],
+            ['object', CompiledExpression::OBJECT],
+            ['array', CompiledExpression::ARR],
+            ['boolean', CompiledExpression::BOOLEAN],
+            ['bool', CompiledExpression::BOOLEAN],
+            ['NULL', CompiledExpression::NULL],
+        ];
+    }
+}


### PR DESCRIPTION
The exception `Type 'bool' is not supported` was thrown when I tried to analyze this kind of code:

```php
class Foo {
    public function bar(bool $param) {}
}
```