### PR TITLE
Do not consider "parent" calls as static

### DIFF
--- a/src/Compiler/Expression/StaticCall.php
+++ b/src/Compiler/Expression/StaticCall.php
@@ -43,7 +43,7 @@ class StaticCall extends AbstractExpressionCompiler
             }
 
             $method = $classDefinition->getMethod($name, true);
-            if (!$method->isStatic()) {
+            if ($expr->class->parts[0] !== 'parent' && !$method->isStatic()) {
                 $context->notice(
                     'undefined-scall',
                     sprintf('Method %s() is not static but it was called as static way', $name),


### PR DESCRIPTION
Fixes incorrect notices like this one:

> Notice:  Method __construct() is not static but it was called as static way in src/Compiler/Parameter.php on 21 [undefined-scall]