### PR TITLE
It's ok to omit the break/return in the last case statement of a switch

### DIFF
--- a/src/Analyzer/Pass/Statement/MissingBreakStatement.php
+++ b/src/Analyzer/Pass/Statement/MissingBreakStatement.php
@@ -20,9 +20,16 @@ class MissingBreakStatement implements Pass\ConfigurablePassInterface, Pass\Anal
     public function pass(Stmt\Switch_ $switchStmt, Context $context)
     {
         $result = false;
+        $caseStmts = $switchStmt->cases;
+
+        if (count($caseStmts) < 2) {
+            return $result;
+        }
+
+        array_pop($caseStmts); // the last case statement CAN have no "break" or "return"
 
         /** @var Stmt\Case_ $case */
-        foreach ($switchStmt->cases as $case) {
+        foreach ($caseStmts as $case) {
             $result = $this->checkCaseStatement($case, $context) || $result;
         }
 
@@ -79,16 +86,6 @@ class MissingBreakStatement implements Pass\ConfigurablePassInterface, Pass\Anal
 
             // or for a return
             if ($node instanceof Stmt\Return_) {
-                // but emit a notice if it's empty.
-                if (!$node->expr) {
-                    $context->notice(
-                        'missing_break_statement',
-                        'Empty return in "case" statement',
-                        $node
-                    );
-                    return true;
-                }
-
                 return false;
             }
         }

--- a/tests/analyze-fixtures/Statement/MissingBreakStatement.php
+++ b/tests/analyze-fixtures/Statement/MissingBreakStatement.php
@@ -22,9 +22,6 @@ class MissingBreakStatement
             case 'foo':
                 $value = 'bar';
                 break;
-            case 'error':
-                $value = 'an empty return looks a bit weird in a switch';
-                return;
             default:
                 return 'what?';
         }
@@ -64,7 +61,44 @@ class MissingBreakStatement
                 $value = 'yay!';
                 break;
             default:
-                return 'what?';
+                $value = 'what?';
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function testValidSwitchWithMissingBreakForLastCase()
+    {
+        $value = 'foo';
+
+        switch ('hello') {
+            case 'hello':
+            case 'bar':
+                $value = 'baz';
+                break;
+            case 'foo':
+                $value = 'yay!';
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function missingBreakOnLastCaseWithDefault()
+    {
+        switch ('hello') {
+            case 'bar':
+                $value = 'baz';
+                break;
+            case 'foo':
+                $value = 'yay!';
+            default:
+                $value = 'default';
         }
 
         return $value;
@@ -79,11 +113,10 @@ class MissingBreakStatement
         "file":"MissingBreakStatement.php",
         "line":19
     },
-
     {
         "type":"missing_break_statement",
-        "message":"Empty return in \"case\" statement",
+        "message":"Missing \"break\" statement",
         "file":"MissingBreakStatement.php",
-        "line":26
+        "line":97
     }
 ]


### PR DESCRIPTION
Fixes #127 