### PR TITLE
Fix Bug #107

### DIFF
--- a/src/Compiler/Expression.php
+++ b/src/Compiler/Expression.php
@@ -388,13 +388,15 @@ class Expression
 
     /**
      * @param Node\Expr\Variable $expr
+     * @param mixed $value
+     * @param int $type
      * @return CompiledExpression
      */
-    public function declareVariable(Node\Expr\Variable $expr)
+    public function declareVariable(Node\Expr\Variable $expr, $value = null, $type = CompiledExpression::UNKNOWN)
     {
         $variable = $this->context->getSymbol($expr->name);
         if (!$variable) {
-            $variable = new Variable($expr->name, null, CompiledExpression::UNKNOWN, $this->context->getCurrentBranch());
+            $variable = new Variable($expr->name, $value, $type, $this->context->getCurrentBranch());
             $this->context->addVariable($variable);
         }
 
@@ -485,7 +487,7 @@ class Expression
             }
 
             return new CompiledExpression(CompiledExpression::UNKNOWN);
-        } elseif (!$scopeExpression->canBeObject()) {
+        } elseif ($scopeExpression->canBeObject()) {
             return new CompiledExpression(CompiledExpression::UNKNOWN);
         }
 

--- a/src/Compiler/Statement/ForeachSt.php
+++ b/src/Compiler/Statement/ForeachSt.php
@@ -6,6 +6,7 @@
 namespace PHPSA\Compiler\Statement;
 
 use PHPSA\Context;
+use PHPSA\CompiledExpression;
 
 class ForeachSt extends AbstractCompiler
 {
@@ -21,11 +22,11 @@ class ForeachSt extends AbstractCompiler
         $context->getExpressionCompiler()->compile($stmt->expr);
 
         if ($stmt->keyVar) {
-            $context->getExpressionCompiler()->declareVariable($stmt->keyVar);
+            $context->getExpressionCompiler()->declareVariable($stmt->keyVar, null, CompiledExpression::MIXED);
         }
 
         if ($stmt->valueVar) {
-            $context->getExpressionCompiler()->declareVariable($stmt->valueVar);
+            $context->getExpressionCompiler()->declareVariable($stmt->valueVar, null, CompiledExpression::MIXED);
         }
 
         if (count($stmt->stmts) > 0) {


### PR DESCRIPTION
Hey!

Type: bug fix

Link to issue: Resolves #107 

This pull request affects the following components: **(please check boxes)**

* [x] Core
* [ ] Analyzer
* [x] Compiler
* [ ] Control Flow Graph
* [ ] Documentation

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](/.github/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

changed variable type of foreach variables to mixed (since the array is compiled before they are always mixed or error before)
With this fix we have no more notices for property fetch on non object when the variable is from foreach

