### PR TITLE
Add Notice message for more than on property in same statement definition

### DIFF
--- a/fixtures/Compiling/statements/MultiplePropertiesDefinition.php
+++ b/fixtures/Compiling/statements/MultiplePropertiesDefinition.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @author Leonardo Mata https://github.com/barroca <barroca@gmail.com>
+ */
+
+namespace Tests\Compiling\Statements;
+
+/**
+ * Class MultiplePropertiesDefinition
+ */
+class MultiplePropertiesDefinition
+{
+    public $a, $b = 1;
+}
+
+
+

--- a/fixtures/Compiling/statements/SinglePropertyDefinition.php
+++ b/fixtures/Compiling/statements/SinglePropertyDefinition.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @author Leonardo Mata https://github.com/barroca <barroca@gmail.com>
+ */
+
+namespace Tests\Compiling\Statements;
+
+
+/**
+ * Class SinglePropertyDefinition
+ */
+class SinglePropertyDefinition
+{
+    public $a = 1;
+}

--- a/fixtures/simple/code-smell/DivisionZero.php
+++ b/fixtures/simple/code-smell/DivisionZero.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Simple\CodeSmell;
 
-class DevisionZero
+class DivisionZero
 {
     /**
      * @return float

--- a/src/Analyzer/Factory.php
+++ b/src/Analyzer/Factory.php
@@ -44,6 +44,7 @@ class Factory
             [
                 new AnalyzerPass\Statement\MagicMethod\GetParametersCheck(),
                 new AnalyzerPass\Statement\DoNotUseGoto(),
+                new AnalyzerPass\Statement\HasMoreThanOneProperty(),
                 new AnalyzerPass\Statement\MissingBreakStatement(),
                 new AnalyzerPass\Statement\MissingVisibility(),
                 new AnalyzerPass\Statement\MethodCannotReturn(),

--- a/src/Analyzer/Pass/Statement/HasMoreThanOneProperty.php
+++ b/src/Analyzer/Pass/Statement/HasMoreThanOneProperty.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @author Leonardo da Mata https://github.com/barroca <barroca@gmail.com>
+ */
+namespace PHPSA\Analyzer\Pass\Statement;
+
+use PhpParser\Node\Stmt\Property;
+use PHPSA\Analyzer\Pass;
+use PHPSA\Context;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+
+class HasMoreThanOneProperty implements Pass\ConfigurablePassInterface, Pass\AnalyzerPassInterface
+{
+    /**
+     * @param Property $prop
+     * @param Context $context
+     * @return bool
+     */
+    public function pass(Property $prop, Context $context)
+    {
+        if (count($prop->props) > 1) {
+            $context->notice('limit.properties', 'Number of properties larger than one.', $prop);
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @return TreeBuilder
+     */
+    public function getConfiguration()
+    {
+        $treeBuilder = new TreeBuilder();
+        $treeBuilder->root('limit.properties')
+            ->canBeDisabled()
+        ;
+
+        return $treeBuilder;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRegister()
+    {
+        return [
+            Property::class,
+        ];
+    }
+}

--- a/tests/analyze-fixtures/Statement/TestMultipleProperties.php
+++ b/tests/analyze-fixtures/Statement/TestMultipleProperties.php
@@ -21,6 +21,6 @@ class TestSingleProperty
         "type":"limit.properties",
         "message":"Number of properties larger than one.",
         "file":"TestMultipleProperties.php",
-        "line":6
+        "line":8
     }
 ]

--- a/tests/analyze-fixtures/Statement/TestMultipleProperties.php
+++ b/tests/analyze-fixtures/Statement/TestMultipleProperties.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @author Leonardo da Mata https://github.com/barroca <barroca@gmail.com>
+ */
+namespace Tests\Analyze\Fixtures\Statement;
+
+class TestMultipleProperties 
+{
+    public $a, $b = 1;
+}
+
+class TestSingleProperty
+{
+	public $a = 1;
+}
+
+?>
+----------------------------
+[
+    {
+        "type":"limit.properties",
+        "message":"Number of properties larger than one.",
+        "file":"TestMultipleProperties.php",
+        "line":6
+    }
+]


### PR DESCRIPTION
Hey!

Type: new feature

Link to issue:
Closes #165 

This pull request affects the following components: **(please check boxes)**

* [ ] Core
* [x] Analyzer
* [ ] Compiler
* [ ] Control Flow Graph
* [ ] Documentation

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](/.github/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

-Add Notice Message when definition of multiple properties on the same statement.
-Fix typo of division word

Thanks

