### PR TITLE
[Analyzer] Dont use static:: in final class #164

### DIFF
--- a/src/Analyzer/Factory.php
+++ b/src/Analyzer/Factory.php
@@ -25,6 +25,7 @@ class Factory
                 new AnalyzerPass\Expression\VariableVariableUsage(),
                 new AnalyzerPass\Expression\Casts(),
                 new AnalyzerPass\Expression\EvalUsage(),
+                new AnalyzerPass\Expression\FinalStaticUsage(),
                 // Arrays
                 new AnalyzerPass\Expression\ArrayShortDefinition(),
                 new AnalyzerPass\Expression\ArrayDuplicateKeys(),

--- a/src/Analyzer/Pass/Expression/FinalStaticUsage.php
+++ b/src/Analyzer/Pass/Expression/FinalStaticUsage.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace PHPSA\Analyzer\Pass\Expression;
+
+use PhpParser\Node\Expr;
+use PHPSA\Analyzer\Pass\AnalyzerPassInterface;
+use PHPSA\Context;
+use PHPSA\Definition\ClassDefinition;
+
+class FinalStaticUsage implements AnalyzerPassInterface
+{
+    /**
+     * @param Expr\StaticCall $expr
+     * @param Context $context
+     * @return bool
+     */
+    public function pass(Expr\StaticCall $expr, Context $context)
+    {
+        $classObject = $context->scope->getPointer()->getObject();
+        if (!$classObject instanceof ClassDefinition || !$classObject->isFinal()) {
+            return false;
+        }
+
+        if ($expr->class->getFirst() !== 'static') {
+            return false;
+        }
+
+        $context->notice(
+            'error.final-static-usage',
+            'Don\'t use static:: in final class',
+            $expr
+        );
+
+        return true;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRegister()
+    {
+        return [
+            Expr\StaticCall::class,
+        ];
+    }
+}

--- a/src/Definition/ClassDefinition.php
+++ b/src/Definition/ClassDefinition.php
@@ -118,7 +118,7 @@ class ClassDefinition extends ParentDefinition
         foreach ($property->props as $propertyDefinition) {
             $this->properties[$propertyDefinition->name] = $propertyDefinition;
         }
-        
+
         $this->propertyStatements[] = $property;
     }
 
@@ -329,6 +329,14 @@ class ClassDefinition extends ParentDefinition
     public function isAbstract()
     {
         return (bool) ($this->type & Node\Stmt\Class_::MODIFIER_ABSTRACT);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isFinal()
+    {
+        return (bool) ($this->type & Node\Stmt\Class_::MODIFIER_FINAL);
     }
 
     /**

--- a/tests/analyze-fixtures/Expression/FinalStaticUsage.php
+++ b/tests/analyze-fixtures/Expression/FinalStaticUsage.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Analyze\Fixtures\Expression;
+
+final class FinalStaticUsage
+{
+    public static function test()
+    {
+        static::test1();
+    }
+
+    public static function test1()
+    {
+    }
+}
+?>
+----------------------------
+[
+    {
+        "type":"error.final-static-usage",
+        "message":"Don't use static:: in final class",
+        "file":"FinalStaticUsage.php",
+        "line":8
+    }
+]


### PR DESCRIPTION
Hey!

Type: new feature

Link to issue: https://github.com/ovr/phpsa/issues/164

This pull request affects the following components: **(please check boxes)**

* [ ] Core
* [x] Analyzer
* [ ] Compiler
* [ ] Control Flow Graph
* [ ] Documentation

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](/.github/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: Checks wether static calls are used in final classes.

Thanks

