### PR TITLE
Add Missing Docblock analyzer

### DIFF
--- a/src/Analyzer/Factory.php
+++ b/src/Analyzer/Factory.php
@@ -51,6 +51,7 @@ class Factory
                 new AnalyzerPass\Statement\MethodCannotReturn(),
                 new AnalyzerPass\Statement\UnexpectedUseOfThis(),
                 new AnalyzerPass\Statement\TestAnnotation(),
+                new AnalyzerPass\Statement\MissingDocblock(),
                 new AnalyzerPass\Statement\OldConstructor(),
                 new AnalyzerPass\Statement\ConstantNaming(),
                 new AnalyzerPass\Statement\DoNotUseInlineHTML(),

--- a/src/Analyzer/Pass/Statement/MissingDocblock.php
+++ b/src/Analyzer/Pass/Statement/MissingDocblock.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace PHPSA\Analyzer\Pass\Statement;
+
+use PhpParser\Node\Stmt;
+use PHPSA\Analyzer\Pass\AnalyzerPassInterface;
+use PHPSA\Context;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+
+class MissingDocblock implements AnalyzerPassInterface
+{
+    /**
+     * @param Stmt $stmt
+     * @param Context $context
+     * @return bool
+     */
+    public function pass(Stmt $stmt, Context $context)
+    {
+        if ($stmt->getDocComment() === null) {
+            $context->notice(
+                'missing_docblock',
+                'Missing Docblock',
+                $stmt
+            );
+
+            return true;
+        }
+        
+        return false;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRegister()
+    {
+        return [
+            Stmt\Class_::class,
+            Stmt\ClassMethod::class,
+            Stmt\Property::class,
+            Stmt\Function_::class,
+            Stmt\Trait_::class,
+            Stmt\Interface_::class,
+            Stmt\ClassConst::class,
+        ];
+    }
+}

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -95,6 +95,20 @@ class Compiler
             $function->compile($context);
         }
 
+        foreach ($this->traits as $trait) {
+            /**
+             * @todo Configuration
+             *
+             * Ignore traits compiling from vendor
+             */
+            $checkVendor = strpos($function->getFilepath(), './vendor');
+            if ($checkVendor !== false && $checkVendor < 3) {
+                continue;
+            }
+
+            $trait->compile($context);
+        }
+
         foreach ($this->classes as $class) {
             /**
              * @todo Configuration

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -101,7 +101,7 @@ class Compiler
              *
              * Ignore traits compiling from vendor
              */
-            $checkVendor = strpos($function->getFilepath(), './vendor');
+            $checkVendor = strpos($trait->getFilepath(), './vendor');
             if ($checkVendor !== false && $checkVendor < 3) {
                 continue;
             }

--- a/src/Compiler/Expression.php
+++ b/src/Compiler/Expression.php
@@ -329,12 +329,6 @@ class Expression
     {
         $docBlock = $st->getDocComment();
         if (!$docBlock) {
-            $this->context->notice(
-                'missing-docblock',
-                sprintf('Missing docblock for $%s property', $st->props[0]->name),
-                $st
-            );
-
             return new CompiledExpression();
         }
 

--- a/src/Definition/ClassMethod.php
+++ b/src/Definition/ClassMethod.php
@@ -69,14 +69,6 @@ class ClassMethod extends AbstractDefinition
         $this->compiled = true;
         $context->scopePointer = $this->getPointer();
 
-        if ($this->statement->getDocComment() === null) {
-            $context->notice(
-                'missing-docblock',
-                sprintf('Missing docblock for %s() method', $this->name),
-                $this->statement
-            );
-        }
-
         /**
          * It's not needed to compile empty method via it's abstract
          */

--- a/src/Definition/FunctionDefinition.php
+++ b/src/Definition/FunctionDefinition.php
@@ -8,6 +8,7 @@ namespace PHPSA\Definition;
 use PHPSA\CompiledExpression;
 use PHPSA\Context;
 use PhpParser\Node;
+use PHPSA\Compiler\Event;
 
 /**
  * Class FunctionDefinition
@@ -58,6 +59,14 @@ class FunctionDefinition extends ParentDefinition
         if ($this->compiled) {
             return true;
         }
+
+        $context->getEventManager()->fire(
+            Event\StatementBeforeCompile::EVENT_NAME,
+            new Event\StatementBeforeCompile(
+                $this->statement,
+                $context
+            )
+        );
 
         $context->setFilepath($this->filepath);
         $this->compiled = true;

--- a/src/Definition/TraitDefinition.php
+++ b/src/Definition/TraitDefinition.php
@@ -7,6 +7,7 @@ namespace PHPSA\Definition;
 
 use PHPSA\Context;
 use PhpParser\Node\Stmt;
+use PHPSA\Compiler\Event;
 
 class TraitDefinition extends ParentDefinition
 {
@@ -39,6 +40,14 @@ class TraitDefinition extends ParentDefinition
      */
     public function compile(Context $context)
     {
+        $context->getEventManager()->fire(
+            Event\StatementBeforeCompile::EVENT_NAME,
+            new Event\StatementBeforeCompile(
+                $this->statement,
+                $context
+            )
+        );
+
         return true;
     }
 

--- a/tests/analyze-fixtures/Statement/MissingDocblock.php
+++ b/tests/analyze-fixtures/Statement/MissingDocblock.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Analyze\Fixtures\Statement;
+
+class MissingDocblock
+{
+    public $noDocblock = 1;
+
+    const NODOC = 1;
+
+    public function noDocblock()
+    {
+        return 1;
+    }
+}
+
+function noDocblockFunc() {
+    return 1;
+}
+
+trait noDocblockTrait
+{
+
+}
+
+//interface noDocblockInterface {} Interface currently not supported
+
+/**
+ * Test
+ */
+class WithDocblock
+{
+    /**
+     * Test
+     */
+    public $withDocblock = 1;
+
+    /**
+     * Test
+     */
+    const WITHDOC = 1;
+
+    /**
+     * Test
+     */
+    public function withDocblock()
+    {
+        return 2;
+    }
+}
+
+/**
+ * Test
+ */
+function withDocblockFunc() {
+    return 1;
+}
+
+/**
+ * Test
+ */
+trait withDocblockTrait
+{
+
+}
+
+//interface withDocblockInterface {} Interface currently not supported
+?>
+----------------------------
+[
+    {
+        "type":"missing_docblock",
+        "message":"Missing Docblock",
+        "file":"MissingDocblock.php",
+        "line":4
+    },
+    {
+        "type":"missing_docblock",
+        "message":"Missing Docblock",
+        "file":"MissingDocblock.php",
+        "line":6
+    },
+    {
+        "type":"missing_docblock",
+        "message":"Missing Docblock",
+        "file":"MissingDocblock.php",
+        "line":8
+    },
+    {
+        "type":"missing_docblock",
+        "message":"Missing Docblock",
+        "file":"MissingDocblock.php",
+        "line":10
+    },
+    {
+        "type":"missing_docblock",
+        "message":"Missing Docblock",
+        "file":"MissingDocblock.php",
+        "line":16
+    },
+    {
+        "type":"missing_docblock",
+        "message":"Missing Docblock",
+        "file":"MissingDocblock.php",
+        "line":20
+    }
+]


### PR DESCRIPTION
Hey!

Type: bug fix & new feature

Link to issue: #95 

This pull request affects the following components **(please check boxes):**

* [x] Core
* [x] Analyzer
* [x] Compiler
* [ ] Control Flow Graph
* [ ] Documentation

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/ovr/phpsa/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:
- Added missing docblock analyzer
- removed already existing missing docblock notices
- Add compile events for functions and traits

For interface compile events this is waiting for merge PR #157 