### PR TITLE
Refactor Expression class

### DIFF
--- a/src/Compiler/Expression.php
+++ b/src/Compiler/Expression.php
@@ -205,6 +205,8 @@ class Expression
                 return new Expression\ArrayOp();
             case Node\Expr\Closure::class:
                 return new Expression\Closure();
+            case Node\Expr\ConstFetch::class:
+                return new Expression\ConstFetch();
             case Node\Expr\UnaryMinus::class:
                 return new Expression\Operators\UnaryMinus();
             case Node\Expr\UnaryPlus::class:
@@ -281,8 +283,6 @@ class Expression
             /**
              * Expressions
              */
-            case Node\Expr\ConstFetch::class:
-                return $this->constFetch($expr);
             case Node\Name::class:
                 return $this->getNodeName($expr);
             case Node\Name\FullyQualified::class:
@@ -688,29 +688,5 @@ class Expression
         );
 
         return new CompiledExpression();
-    }
-
-    /**
-     * Convert const fetch expr to CompiledExpression
-     *
-     * @param Node\Expr\ConstFetch $expr
-     * @return CompiledExpression
-     */
-    protected function constFetch(Node\Expr\ConstFetch $expr)
-    {
-        if ($expr->name instanceof Node\Name) {
-            if ($expr->name->parts[0] === 'true') {
-                return new CompiledExpression(CompiledExpression::BOOLEAN, true);
-            }
-
-            if ($expr->name->parts[0] === 'false') {
-                return new CompiledExpression(CompiledExpression::BOOLEAN, false);
-            }
-        }
-
-        /**
-         * @todo Implement check
-         */
-        return $this->compile($expr->name);
     }
 }

--- a/src/Compiler/Expression.php
+++ b/src/Compiler/Expression.php
@@ -207,6 +207,8 @@ class Expression
                 return new Expression\Closure();
             case Node\Expr\ConstFetch::class:
                 return new Expression\ConstFetch();
+            case Node\Expr\ClassConstFetch::class:
+                return new Expression\ClassConstFetch();
             case Node\Expr\UnaryMinus::class:
                 return new Expression\Operators\UnaryMinus();
             case Node\Expr\UnaryPlus::class:
@@ -271,8 +273,6 @@ class Expression
                 return $this->passPropertyFetch($expr);
             case Node\Stmt\Property::class:
                 return $this->passProperty($expr);
-            case Node\Expr\ClassConstFetch::class:
-                return $this->passConstFetch($expr);
             case Node\Expr\Assign::class:
                 return $this->passSymbol($expr);
             case Node\Expr\AssignRef::class:
@@ -499,33 +499,6 @@ class Expression
         );
 
         return new CompiledExpression(CompiledExpression::UNKNOWN);
-    }
-
-    /**
-     * @param Node\Expr\ClassConstFetch $expr
-     * @return CompiledExpression
-     */
-    protected function passConstFetch(Node\Expr\ClassConstFetch $expr)
-    {
-        $leftCE = $this->compile($expr->class);
-        if ($leftCE->isObject()) {
-            $leftCEValue = $leftCE->getValue();
-            if ($leftCEValue instanceof ClassDefinition) {
-                if (!$leftCEValue->hasConst($expr->name, true)) {
-                    $this->context->notice(
-                        'undefined-const',
-                        sprintf('Constant %s does not exist in %s scope', $expr->name, $expr->class),
-                        $expr
-                    );
-                    return new CompiledExpression(CompiledExpression::UNKNOWN);
-                }
-
-                return new CompiledExpression();
-            }
-        }
-
-        $this->context->debug('Unknown const fetch', $expr);
-        return new CompiledExpression();
     }
 
     /**

--- a/src/Compiler/Expression.php
+++ b/src/Compiler/Expression.php
@@ -201,6 +201,8 @@ class Expression
             /**
              * Other
              */
+            case Node\Expr\Array_::class:
+                return new Expression\ArrayOp();
             case Node\Expr\Closure::class:
                 return new Expression\Closure();
             case Node\Expr\UnaryMinus::class:
@@ -279,8 +281,6 @@ class Expression
             /**
              * Expressions
              */
-            case Node\Expr\Array_::class:
-                return $this->getArray($expr);
             case Node\Expr\ConstFetch::class:
                 return $this->constFetch($expr);
             case Node\Name::class:
@@ -688,44 +688,6 @@ class Expression
         );
 
         return new CompiledExpression();
-    }
-
-    /**
-     * Compile Array_ expression to CompiledExpression
-     *
-     * @param Node\Expr\Array_ $expr
-     * @return CompiledExpression
-     */
-    protected function getArray(Node\Expr\Array_ $expr)
-    {
-        if ($expr->items === []) {
-            return new CompiledExpression(CompiledExpression::ARR, []);
-        }
-
-        $resultArray = [];
-
-        foreach ($expr->items as $item) {
-            $compiledValueResult = $this->compile($item->value);
-            if ($item->key) {
-                $compiledKeyResult = $this->compile($item->key);
-                switch ($compiledKeyResult->getType()) {
-                    case CompiledExpression::INTEGER:
-                    case CompiledExpression::DOUBLE:
-                    case CompiledExpression::BOOLEAN:
-                    case CompiledExpression::NULL:
-                    case CompiledExpression::STRING:
-                        $resultArray[$compiledKeyResult->getValue()] = $compiledValueResult->getValue();
-                        break;
-                    default:
-                        $this->context->debug("Type {$compiledKeyResult->getType()} is not supported for key value");
-                        return new CompiledExpression(CompiledExpression::ARR);
-                }
-            } else {
-                $resultArray[] = $compiledValueResult->getValue();
-            }
-        }
-
-        return new CompiledExpression(CompiledExpression::ARR, $resultArray);
     }
 
     /**

--- a/src/Compiler/Expression.php
+++ b/src/Compiler/Expression.php
@@ -215,6 +215,8 @@ class Expression
                 return new Expression\ClassConstFetch();
             case Node\Expr\PropertyFetch::class:
                 return new Expression\PropertyFetch();
+            case Node\Expr\ArrayDimFetch::class:
+                return new Expression\ArrayDimFetch();
             case Node\Expr\UnaryMinus::class:
                 return new Expression\Operators\UnaryMinus();
             case Node\Expr\UnaryPlus::class:

--- a/src/Compiler/Expression.php
+++ b/src/Compiler/Expression.php
@@ -229,6 +229,8 @@ class Expression
                 return new Expression\CloneOp();
             case Node\Expr\Ternary::class:
                 return new Expression\Ternary();
+            case Node\Expr\Variable::class:
+                return new Expression\Variable();
         }
 
         return false;
@@ -277,8 +279,6 @@ class Expression
                 return $this->passSymbol($expr);
             case Node\Expr\AssignRef::class:
                 return $this->passSymbolByRef($expr);
-            case Node\Expr\Variable::class:
-                return $this->passExprVariable($expr);
 
             /**
              * Expressions
@@ -639,27 +639,6 @@ class Expression
         }
 
         $this->context->debug('Unknown how to pass symbol by ref');
-        return new CompiledExpression();
-    }
-
-    /**
-     * @param Node\Expr\Variable $expr
-     * @return CompiledExpression
-     */
-    protected function passExprVariable(Node\Expr\Variable $expr)
-    {
-        $variable = $this->context->getSymbol($expr->name);
-        if ($variable) {
-            $variable->incGets();
-            return new CompiledExpression($variable->getType(), $variable->getValue(), $variable);
-        }
-
-        $this->context->notice(
-            'undefined-variable',
-            sprintf('You are trying to use an undefined variable $%s', $expr->name),
-            $expr
-        );
-
         return new CompiledExpression();
     }
 }

--- a/src/Compiler/Expression/ArrayDimFetch.php
+++ b/src/Compiler/Expression/ArrayDimFetch.php
@@ -25,7 +25,7 @@ class ArrayDimFetch extends AbstractExpressionCompiler
         $var = $compiler->compile($expr->var);
         $dim = $compiler->compile($expr->dim);
 
-        if (!$var->isArray() && !$var->getType() == CompiledExpression::MIXED) {
+        if (!$var->isArray()) {
             $context->notice(
                 'array_dim_fetch_on_non_array',
                 "It's not possible to fetch an array element on a non array",

--- a/src/Compiler/Expression/ArrayDimFetch.php
+++ b/src/Compiler/Expression/ArrayDimFetch.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace PHPSA\Compiler\Expression;
+
+use PHPSA\CompiledExpression;
+use PHPSA\Context;
+use PHPSA\Compiler\Expression;
+use PHPSA\Compiler\Expression\AbstractExpressionCompiler;
+
+class ArrayDimFetch extends AbstractExpressionCompiler
+{
+    protected $name = 'PhpParser\Node\Expr\ArrayDimFetch';
+
+    /**
+     * $array[1], $array[$var], $array["string"]
+     *
+     * @param \PhpParser\Node\Expr\ArrayDimFetch $expr
+     * @param Context $context
+     * @return CompiledExpression
+     */
+    protected function compile($expr, Context $context)
+    {
+        $compiler = $context->getExpressionCompiler();
+
+        $var = $compiler->compile($expr->var);
+        $dim = $compiler->compile($expr->dim);
+
+        if (!$var->isArray() && !$var->getType() == CompiledExpression::MIXED) {
+            $context->notice(
+                'array_dim_fetch_on_non_array',
+                "It's not possible to fetch an array element on a non array",
+                $expr
+            );
+            
+            return new CompiledExpression();
+        }
+
+        if (!in_array($dim->getValue(), $var->getValue())) {
+            $context->notice(
+                'array_dim_fetch_not_found',
+                "The array does not contain this value",
+                $expr
+            );
+
+            return new CompiledExpression();
+        }
+
+        $resultArray = $var->getValue();
+
+        return CompiledExpression::fromZvalValue($resultArray[$dim->getValue()]);
+    }
+}

--- a/src/Compiler/Expression/ArrayOp.php
+++ b/src/Compiler/Expression/ArrayOp.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace PHPSA\Compiler\Expression;
+
+use PHPSA\CompiledExpression;
+use PHPSA\Context;
+use PHPSA\Compiler\Expression;
+use PHPSA\Compiler\Expression\AbstractExpressionCompiler;
+
+class ArrayOp extends AbstractExpressionCompiler
+{
+    protected $name = 'PhpParser\Node\Expr\Array_';
+
+    /**
+     * [] array()
+     *
+     * @param \PhpParser\Node\Expr\Array_ $expr
+     * @param Context $context
+     * @return CompiledExpression
+     */
+    protected function compile($expr, Context $context)
+    {
+        $compiler = $context->getExpressionCompiler();
+
+        if ($expr->items === []) {
+            return new CompiledExpression(CompiledExpression::ARR, []);
+        }
+
+        $resultArray = [];
+
+        foreach ($expr->items as $item) {
+            $compiledValueResult = $compiler->compile($item->value);
+            if ($item->key) {
+                $compiledKeyResult = $compiler->compile($item->key);
+                switch ($compiledKeyResult->getType()) {
+                    case CompiledExpression::INTEGER:
+                    case CompiledExpression::DOUBLE:
+                    case CompiledExpression::BOOLEAN:
+                    case CompiledExpression::NULL:
+                    case CompiledExpression::STRING:
+                        $resultArray[$compiledKeyResult->getValue()] = $compiledValueResult->getValue();
+                }
+            } else {
+                $resultArray[] = $compiledValueResult->getValue();
+            }
+        }
+
+        return new CompiledExpression(CompiledExpression::ARR, $resultArray);
+    }
+}

--- a/src/Compiler/Expression/Assign.php
+++ b/src/Compiler/Expression/Assign.php
@@ -79,7 +79,7 @@ class Assign extends AbstractExpressionCompiler
             }
         }
 
-        $context->debug('Unknown how to pass symbol');
+        $context->debug('Unknown how to pass symbol', $expr);
         return new CompiledExpression();
     }
 

--- a/src/Compiler/Expression/Assign.php
+++ b/src/Compiler/Expression/Assign.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace PHPSA\Compiler\Expression;
+
+use PHPSA\CompiledExpression;
+use PHPSA\Context;
+use PHPSA\Compiler\Expression;
+use PHPSA\Compiler\Expression\AbstractExpressionCompiler;
+use PhpParser\Node;
+
+class Assign extends AbstractExpressionCompiler
+{
+    protected $name = 'PhpParser\Node\Expr\Assign';
+
+    /**
+     * $a = 3;
+     *
+     * @param \PhpParser\Node\Expr\Assign $expr
+     * @param Context $context
+     * @return CompiledExpression
+     */
+    protected function compile($expr, Context $context)
+    {
+        $compiler = $context->getExpressionCompiler();
+
+        $compiledExpression = $compiler->compile($expr->expr);
+
+        if ($expr->var instanceof Node\Expr\List_) {
+            $isCorrectType = $compiledExpression->isArray();
+
+            foreach ($expr->var->vars as $key => $var) {
+                if (!$var instanceof Node\Expr\Variable) {
+                    continue;
+                }
+
+                if ($var->name instanceof Node\Expr\Variable) {
+                    $this->compileVariableDeclaration($compiler->compile($var->name), new CompiledExpression(), $context);
+                    continue;
+                }
+
+                $symbol = $context->getSymbol($var->name);
+                if (!$symbol) {
+                    $symbol = new \PHPSA\Variable(
+                        $var->name,
+                        null,
+                        CompiledExpression::UNKNOWN,
+                        $context->getCurrentBranch()
+                    );
+                    $context->addVariable($symbol);
+                }
+
+                if (!$isCorrectType) {
+                    $symbol->modify(CompiledExpression::NULL, null);
+                }
+
+                $symbol->incSets();
+            }
+
+            return new CompiledExpression();
+        }
+
+        if ($expr->var instanceof Node\Expr\Variable) {
+            $this->compileVariableDeclaration($compiler->compile($expr->var->name), $compiledExpression, $context);
+
+            return $compiledExpression;
+        }
+
+        if ($expr->var instanceof Node\Expr\PropertyFetch) {
+            $compiledExpression = $compiler->compile($expr->var->var);
+            if ($compiledExpression->getType() == CompiledExpression::OBJECT) {
+                $objectDefinition = $compiledExpression->getValue();
+                if ($objectDefinition instanceof ClassDefinition) {
+                    if (is_string($expr->var->name)) {
+                        if ($objectDefinition->hasProperty($expr->var->name)) {
+                            return $compiler->compile($objectDefinition->getProperty($expr->var->name));
+                        }
+                    }
+                }
+            }
+        }
+
+        $context->debug('Unknown how to pass symbol');
+        return new CompiledExpression();
+    }
+
+
+    protected function compileVariableDeclaration(CompiledExpression $variableName, CompiledExpression $value, Context $context)
+    {
+        switch ($variableName->getType()) {
+            case CompiledExpression::STRING:
+                break;
+            default:
+                $context->debug('Unexpected type of Variable name after compile');
+                return new CompiledExpression();
+        }
+
+        $symbol = $context->getSymbol($variableName->getValue());
+        if ($symbol) {
+            $symbol->modify($value->getType(), $value->getValue());
+            $context->modifyReferencedVariables(
+                $symbol,
+                $value->getType(),
+                $value->getValue()
+            );
+        } else {
+            $symbol = new \PHPSA\Variable(
+                $variableName->getValue(),
+                $value->getValue(),
+                $value->getType(),
+                $context->getCurrentBranch()
+            );
+            $context->addVariable($symbol);
+        }
+
+        $symbol->incSets();
+    }
+}

--- a/src/Compiler/Expression/AssignRef.php
+++ b/src/Compiler/Expression/AssignRef.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace PHPSA\Compiler\Expression;
+
+use PHPSA\CompiledExpression;
+use PHPSA\Context;
+use PHPSA\Compiler\Expression;
+use PHPSA\Compiler\Expression\AbstractExpressionCompiler;
+use PhpParser\Node\Expr\Variable as VariableNode;
+
+class AssignRef extends AbstractExpressionCompiler
+{
+    protected $name = 'PhpParser\Node\Expr\AssignRef';
+
+    /**
+     * $a &= $b;
+     *
+     * @param \PhpParser\Node\Expr\AssignRef $expr
+     * @param Context $context
+     * @return CompiledExpression
+     */
+    protected function compile($expr, Context $context)
+    {
+        $compiler = $context->getExpressionCompiler();
+        if ($expr->var instanceof VariableNode) {
+            $name = $expr->var->name;
+
+            $compiledExpression = $compiler->compile($expr->expr);
+            
+            $symbol = $context->getSymbol($name);
+            if ($symbol) {
+                $symbol->modify($compiledExpression->getType(), $compiledExpression->getValue());
+            } else {
+                $symbol = new \PHPSA\Variable(
+                    $name,
+                    $compiledExpression->getValue(),
+                    $compiledExpression->getType(),
+                    $context->getCurrentBranch()
+                );
+                $context->addVariable($symbol);
+            }
+
+            if ($expr->expr instanceof VariableNode) {
+                $rightVarName = $expr->expr->name;
+
+                $rightSymbol = $context->getSymbol($rightVarName);
+                if ($rightSymbol) {
+                    $rightSymbol->incUse();
+                    $symbol->setReferencedTo($rightSymbol);
+                } else {
+                    $context->debug('Cannot fetch variable by name: ' . $rightVarName);
+                }
+            }
+
+            $symbol->incSets();
+            return $compiledExpression;
+        }
+
+        $context->debug('Unknown how to pass symbol by ref');
+        return new CompiledExpression();
+    }
+}

--- a/src/Compiler/Expression/ClassConstFetch.php
+++ b/src/Compiler/Expression/ClassConstFetch.php
@@ -32,7 +32,7 @@ class ClassConstFetch extends AbstractExpressionCompiler
             $leftCEValue = $leftCE->getValue();
             if ($leftCEValue instanceof ClassDefinition) {
                 if (!$leftCEValue->hasConst($expr->name, true)) {
-                    $this->context->notice(
+                    $context->notice(
                         'undefined-const',
                         sprintf('Constant %s does not exist in %s scope', $expr->name, $expr->class),
                         $expr
@@ -44,7 +44,7 @@ class ClassConstFetch extends AbstractExpressionCompiler
             }
         }
 
-        $this->context->debug('Unknown const fetch', $expr);
+        $context->debug('Unknown const fetch', $expr);
         return new CompiledExpression();
     }
 }

--- a/src/Compiler/Expression/ClassConstFetch.php
+++ b/src/Compiler/Expression/ClassConstFetch.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace PHPSA\Compiler\Expression;
+
+use PHPSA\CompiledExpression;
+use PHPSA\Context;
+use PHPSA\Compiler\Expression;
+use PHPSA\Compiler\Expression\AbstractExpressionCompiler;
+
+class ClassConstFetch extends AbstractExpressionCompiler
+{
+    protected $name = 'PhpParser\Node\Expr\ClassConstFetch';
+
+    /**
+     * classname::class, classname::CONSTANTNAME, ...
+     *
+     * @param \PhpParser\Node\Expr\ClassConstFetch $expr
+     * @param Context $context
+     * @return CompiledExpression
+     */
+    protected function compile($expr, Context $context)
+    {
+        $compiler = $context->getExpressionCompiler();
+
+        if ($expr->name == "class") {
+            // @todo return fully qualified classname
+            return new CompiledExpression();
+        }
+
+        $leftCE = $compiler->compile($expr->class);
+        if ($leftCE->isObject()) {
+            $leftCEValue = $leftCE->getValue();
+            if ($leftCEValue instanceof ClassDefinition) {
+                if (!$leftCEValue->hasConst($expr->name, true)) {
+                    $this->context->notice(
+                        'undefined-const',
+                        sprintf('Constant %s does not exist in %s scope', $expr->name, $expr->class),
+                        $expr
+                    );
+                    return new CompiledExpression(CompiledExpression::UNKNOWN);
+                }
+
+                return new CompiledExpression();
+            }
+        }
+
+        $this->context->debug('Unknown const fetch', $expr);
+        return new CompiledExpression();
+    }
+}

--- a/src/Compiler/Expression/ConstFetch.php
+++ b/src/Compiler/Expression/ConstFetch.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace PHPSA\Compiler\Expression;
+
+use PHPSA\CompiledExpression;
+use PHPSA\Context;
+use PHPSA\Compiler\Expression;
+use PHPSA\Compiler\Expression\AbstractExpressionCompiler;
+
+class ConstFetch extends AbstractExpressionCompiler
+{
+    protected $name = 'PhpParser\Node\Expr\ConstFetch';
+
+    /**
+     * true, CONSTANTNAME, ...
+     *
+     * @param \PhpParser\Node\Expr\ConstFetch $expr
+     * @param Context $context
+     * @return CompiledExpression
+     */
+    protected function compile($expr, Context $context)
+    {
+        $compiler = $context->getExpressionCompiler();
+
+        if ($expr->name instanceof Node\Name) {
+            if ($expr->name->parts[0] === 'true') {
+                return new CompiledExpression(CompiledExpression::BOOLEAN, true);
+            }
+
+            if ($expr->name->parts[0] === 'false') {
+                return new CompiledExpression(CompiledExpression::BOOLEAN, false);
+            }
+        }
+
+        /**
+         * @todo Implement check
+         */
+        return $compiler->compile($expr->name);
+    }
+}

--- a/src/Compiler/Expression/EmptyOp.php
+++ b/src/Compiler/Expression/EmptyOp.php
@@ -6,7 +6,7 @@ use PHPSA\CompiledExpression;
 use PHPSA\Context;
 use PHPSA\Compiler\Expression;
 use PHPSA\Compiler\Expression\AbstractExpressionCompiler;
-use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Expr\Variable as VariableNode;
 use PhpParser\Node\Name;
 
 class EmptyOp extends AbstractExpressionCompiler
@@ -22,7 +22,7 @@ class EmptyOp extends AbstractExpressionCompiler
      */
     protected function compile($expr, Context $context)
     {
-        if ($expr->expr instanceof Variable) {
+        if ($expr->expr instanceof VariableNode) {
             $varName = $expr->expr->name;
 
             if ($varName instanceof Name) {

--- a/src/Compiler/Expression/IssetOp.php
+++ b/src/Compiler/Expression/IssetOp.php
@@ -6,7 +6,7 @@ use PHPSA\CompiledExpression;
 use PHPSA\Context;
 use PHPSA\Compiler\Expression;
 use PHPSA\Compiler\Expression\AbstractExpressionCompiler;
-use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Expr\Variable as VariableNode;
 use PhpParser\Node\Name;
 
 class IssetOp extends AbstractExpressionCompiler
@@ -25,7 +25,7 @@ class IssetOp extends AbstractExpressionCompiler
         $result = false;
 
         foreach ($expr->vars as $var) {
-            if ($var instanceof Variable) {
+            if ($var instanceof VariableNode) {
                 $varName = $var->name;
 
                 if ($varName instanceof Name) {

--- a/src/Compiler/Expression/MethodCall.php
+++ b/src/Compiler/Expression/MethodCall.php
@@ -46,7 +46,7 @@ class MethodCall extends AbstractExpressionCompiler
 
                     $method = $calledObject->getMethod($methodName, true);
                     if (!$method) {
-                        $context->debug('getMethod is not working');
+                        $context->debug('getMethod is not working', $expr);
                         return new CompiledExpression();
                     }
 
@@ -72,7 +72,7 @@ class MethodCall extends AbstractExpressionCompiler
             );
         }
 
-        $context->debug('[Unknown] @todo MethodCall');
+        $context->debug('[Unknown] @todo MethodCall', $expr);
         return new CompiledExpression();
     }
 

--- a/src/Compiler/Expression/Operators/NewOp.php
+++ b/src/Compiler/Expression/Operators/NewOp.php
@@ -42,7 +42,7 @@ class NewOp extends AbstractExpressionCompiler
             return new CompiledExpression(CompiledExpression::OBJECT);
         }
 
-        $context->debug('Unknown how to pass new');
+        $context->debug('Unknown how to pass new', $expr);
         return new CompiledExpression();
     }
 }

--- a/src/Compiler/Expression/PropertyFetch.php
+++ b/src/Compiler/Expression/PropertyFetch.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace PHPSA\Compiler\Expression;
+
+use PHPSA\CompiledExpression;
+use PHPSA\Context;
+use PHPSA\Compiler\Expression;
+use PHPSA\Compiler\Expression\AbstractExpressionCompiler;
+
+class PropertyFetch extends AbstractExpressionCompiler
+{
+    protected $name = 'PhpParser\Node\Expr\PropertyFetch';
+
+    /**
+     * classname->property
+     *
+     * @param \PhpParser\Node\Expr\PropertyFetch $expr
+     * @param Context $context
+     * @return CompiledExpression
+     */
+    protected function compile($expr, Context $context)
+    {
+        $compiler = $context->getExpressionCompiler();
+
+        $propertNameCE = $compiler->compile($expr->name);
+
+        $scopeExpression = $compiler->compile($expr->var);
+        if ($scopeExpression->isObject()) {
+            $scopeExpressionValue = $scopeExpression->getValue();
+            if ($scopeExpressionValue instanceof ClassDefinition) {
+                $propertyName = $propertNameCE->isString() ? $propertNameCE->getValue() : false;
+                if ($propertyName) {
+                    if ($scopeExpressionValue->hasProperty($propertyName, true)) {
+                        $property = $scopeExpressionValue->getProperty($propertyName, true);
+                        return $compiler->compile($property);
+                    } else {
+                        $context->notice(
+                            'undefined-property',
+                            sprintf(
+                                'Property %s does not exist in %s scope',
+                                $propertyName,
+                                $scopeExpressionValue->getName()
+                            ),
+                            $expr
+                        );
+                    }
+                }
+            }
+
+            return new CompiledExpression();
+        } elseif ($scopeExpression->canBeObject()) {
+            return new CompiledExpression();
+        }
+
+        $context->notice(
+            'property-fetch-on-non-object',
+            "It's not possible to fetch a property on a non-object",
+            $expr,
+            Check::CHECK_BETA
+        );
+
+        return new CompiledExpression();
+    }
+}

--- a/src/Compiler/Expression/StaticCall.php
+++ b/src/Compiler/Expression/StaticCall.php
@@ -54,7 +54,7 @@ class StaticCall extends AbstractExpressionCompiler
             return new CompiledExpression();
         }
 
-        $context->debug('Unknown static function call');
+        $context->debug('Unknown static function call', $expr);
         return new CompiledExpression();
     }
 }

--- a/src/Compiler/Expression/Variable.php
+++ b/src/Compiler/Expression/Variable.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace PHPSA\Compiler\Expression;
+
+use PHPSA\CompiledExpression;
+use PHPSA\Context;
+use PHPSA\Compiler\Expression;
+use PHPSA\Compiler\Expression\AbstractExpressionCompiler;
+
+class Variable extends AbstractExpressionCompiler
+{
+    protected $name = 'PhpParser\Node\Expr\Variable';
+
+    /**
+     * $a
+     *
+     * @param \PhpParser\Node\Expr\Variable $expr
+     * @param Context $context
+     * @return CompiledExpression
+     */
+    protected function compile($expr, Context $context)
+    {
+        $variable = $context->getSymbol($expr->name);
+        if ($variable) {
+            $variable->incGets();
+            return new CompiledExpression($variable->getType(), $variable->getValue(), $variable);
+        }
+
+        $context->notice(
+            'undefined-variable',
+            sprintf('You are trying to use an undefined variable $%s', $expr->name),
+            $expr
+        );
+
+        return new CompiledExpression();
+    }
+}

--- a/src/Context.php
+++ b/src/Context.php
@@ -271,6 +271,9 @@ class Context
 
             if ($expr) {
                 $this->output->write(':' . $expr->getLine());
+
+                $code = trim($code[$expr->getLine() - 1]);
+                $this->output->writeln("<comment>\t {$code} </comment>");
             }
 
             $this->output->writeln('');

--- a/src/Context.php
+++ b/src/Context.php
@@ -271,9 +271,6 @@ class Context
 
             if ($expr) {
                 $this->output->write(':' . $expr->getLine());
-
-                $code = trim($code[$expr->getLine() - 1]);
-                $this->output->writeln("<comment>\t {$code} </comment>");
             }
 
             $this->output->writeln('');


### PR DESCRIPTION
Hey!

Type: code quality

Link to issue: Resolves #155

This pull request affects the following components **(please check boxes):**

* [ ] Core
* [ ] Analyzer
* [x] Compiler
* [ ] Control Flow Graph
* [ ] Documentation

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/ovr/phpsa/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:
Moves compilers out of expression into own compiler:
- Array_
- ConstFetch
- ClassConstFetch (added if for `::class` this one caused a lot of debug msg for phpsa on phpsa)
- Variable
- PropertyFetch
- AssignRef
- Assign
- ArrayDimFetch