### PR TITLE
Add Multiple Unary Operators analyzer

### DIFF
--- a/docs/05_Analyzers.md
+++ b/docs/05_Analyzers.md
@@ -90,6 +90,10 @@ Checks for a missing docblock for: class, property, class constant, trait, inter
 
 Checks for missing visibility modifiers for properties and methods.
 
+#### MultipleUnaryOperators
+
+Checks for use of multiple unary operators that cancel each other out. For example `!!boolean` or `- -int`. (there is a space between the two minus)
+
 #### OldConstructor
 
 Checks for use of PHP 4 constructors and discourages it.

--- a/src/Analyzer/Factory.php
+++ b/src/Analyzer/Factory.php
@@ -22,6 +22,7 @@ class Factory
             [
                 // Another
                 new AnalyzerPass\Expression\ErrorSuppression(),
+                new AnalyzerPass\Expression\MultipleUnaryOperators(),
                 new AnalyzerPass\Expression\VariableVariableUsage(),
                 new AnalyzerPass\Expression\Casts(),
                 new AnalyzerPass\Expression\EvalUsage(),

--- a/src/Analyzer/Pass/Expression/MultipleUnaryOperators.php
+++ b/src/Analyzer/Pass/Expression/MultipleUnaryOperators.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace PHPSA\Analyzer\Pass\Expression;
+
+use PhpParser\Node\Expr;
+use PHPSA\Analyzer\Pass\AnalyzerPassInterface;
+use PHPSA\Context;
+use PHPSA\CompiledExpression;
+
+class MultipleUnaryOperators implements AnalyzerPassInterface
+{
+    /**
+     * @param Expr $expr
+     * @param Context $context
+     * @return bool
+     */
+    public function pass(Expr $expr, Context $context)
+    {
+        if (get_class($expr->expr) == get_class($expr)) {
+            $context->notice(
+                'multiple_unary_operators',
+                "You are using multiple unary operators. This has no effect",
+                $expr
+            );
+            return true;
+        }
+        
+        return false;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRegister()
+    {
+        return [
+            Expr\UnaryPlus::class,
+            Expr\UnaryMinus::class,
+            Expr\BitwiseNot::class,
+            Expr\BooleanNot::class,
+        ];
+    }
+}

--- a/tests/analyze-fixtures/Expression/MultipleUnaryOperators.php
+++ b/tests/analyze-fixtures/Expression/MultipleUnaryOperators.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Analyze\Fixtures\Expression;
+
+class MultipleUnaryOperators
+{
+    public function doubleBooleanNot()
+    {
+        if (!!true) {
+            return 1;
+        }
+    }
+
+    public function doubleBitwiseNot()
+    {
+        if (~~1) {
+            return 1;
+        }
+    }
+
+    public function doubleUnaryMinus()
+    {
+        if (- -1) {
+            return 1;
+        }
+    }
+
+    public function doubleUnaryPlus()
+    {
+        if (+ +1) {
+            return 1;
+        }
+    }
+
+    public function singleBooleanNot()
+    {
+        if (!true) {
+            return 1;
+        }
+    }
+
+    public function singleBitwiseNot()
+    {
+        if (~1) {
+            return 1;
+        }
+    }
+
+    public function preDec()
+    {
+        $a = 1;
+        if (--$a) {
+            return 1;
+        }
+    }
+
+    public function preInc()
+    {
+        $a = 1;
+        if (++$a) {
+            return 1;
+        }
+    }
+
+}
+?>
+----------------------------
+[
+    {
+        "type":"multiple_unary_operators",
+        "message":"You are using multiple unary operators. This has no effect",
+        "file":"MultipleUnaryOperators.php",
+        "line":8
+    },
+    {
+        "type":"multiple_unary_operators",
+        "message":"You are using multiple unary operators. This has no effect",
+        "file":"MultipleUnaryOperators.php",
+        "line":15
+    },
+    {
+        "type":"multiple_unary_operators",
+        "message":"You are using multiple unary operators. This has no effect",
+        "file":"MultipleUnaryOperators.php",
+        "line":22
+    },
+    {
+        "type":"multiple_unary_operators",
+        "message":"You are using multiple unary operators. This has no effect",
+        "file":"MultipleUnaryOperators.php",
+        "line":29
+    }
+]


### PR DESCRIPTION
Hey!

Type: new feature

Link to issue: Resolves #145 

This pull request affects the following components **(please check boxes):**

* [ ] Core
* [x] Analyzer
* [ ] Compiler
* [ ] Control Flow Graph
* [ ] Documentation

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/ovr/phpsa/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Adds multiple unary operators analyzer. This can detect something like `if(!(!(boolean || boolean)))` 
or `- -1` (double negation not predec operator)

