### PR TITLE
Added expression analyzer for backtick operator

### DIFF
--- a/src/Analyzer/Factory.php
+++ b/src/Analyzer/Factory.php
@@ -27,6 +27,7 @@ class Factory
                 new AnalyzerPass\Expression\EvalUsage(),
                 new AnalyzerPass\Expression\FinalStaticUsage(),
                 new AnalyzerPass\Expression\CompareWithArray(),
+                new AnalyzerPass\Expression\BacktickUsage(),
                 // Arrays
                 new AnalyzerPass\Expression\ArrayShortDefinition(),
                 new AnalyzerPass\Expression\ArrayDuplicateKeys(),

--- a/src/Analyzer/Pass/Expression/BacktickUsage.php
+++ b/src/Analyzer/Pass/Expression/BacktickUsage.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace PHPSA\Analyzer\Pass\Expression;
+
+use PhpParser\Node\Expr;
+use PHPSA\Analyzer\Pass\AnalyzerPassInterface;
+use PHPSA\Context;
+
+class BacktickUsage implements AnalyzerPassInterface
+{
+    /**
+     * @param Expr\ShellExec $expr
+     * @param Context $context
+     * @return bool
+     */
+    public function pass(Expr\ShellExec $expr, Context $context)
+    {
+        $context->notice(
+            'backtick_usage',
+            'It\'s bad practice to use the backtick operator for shell execution',
+            $expr
+        );
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRegister()
+    {
+        return [
+            Expr\ShellExec::class
+        ];
+    }
+}

--- a/tests/analyze-fixtures/Expression/BacktickUsage.php
+++ b/tests/analyze-fixtures/Expression/BacktickUsage.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Compiling\Statements;
+
+class BacktickUsage
+{
+    public function backtickUsage()
+    {
+        $output = `ls -al`;
+    }
+
+    public function noBacktickUsage()
+    {
+        $output = 5;
+    }
+}
+?>
+----------------------------
+[
+    {
+        "type":"backtick_usage",
+        "message":"It's bad practice to use the backtick operator for shell execution",
+        "file":"BacktickUsage.php",
+        "line":8
+    }
+]


### PR DESCRIPTION
Hey!

Type: new feature

Link to issue: #163 

This pull request affects the following components **(please check boxes):**

* [ ] Core
* [x] Analyzer
* [ ] Compiler
* [ ] Control Flow Graph
* [ ] Documentation

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/ovr/phpsa/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:
Added an expression analyzer for the backtick operator since it is bad convention to write shell commands this way.

Thanks

