### PR TITLE
Compiler: include, backtick, yield, yield from

### DIFF
--- a/src/Compiler/Expression.php
+++ b/src/Compiler/Expression.php
@@ -231,12 +231,20 @@ class Expression
                 return new Expression\EmptyOp();
             case Node\Expr\Eval_::class:
                 return new Expression\EvalOp();
+            case Node\Expr\ShellExec::class:
+                return new Expression\ShellExec();
             case Node\Expr\ErrorSuppress::class:
                 return new Expression\ErrorSuppress();
+            case Node\Expr\Include_::class:
+                return new Expression\IncludeOp();
             case Node\Expr\Clone_::class:
                 return new Expression\CloneOp();
             case Node\Expr\Ternary::class:
                 return new Expression\Ternary();
+            case Node\Expr\Yield_::class:
+                return new Expression\YieldOp();
+            case Node\Expr\YieldFrom::class:
+                return new Expression\YieldFrom();
             case Node\Expr\Variable::class:
                 return new Expression\Variable();
         }

--- a/src/Compiler/Expression.php
+++ b/src/Compiler/Expression.php
@@ -215,6 +215,8 @@ class Expression
                 return new Expression\ClassConstFetch();
             case Node\Expr\PropertyFetch::class:
                 return new Expression\PropertyFetch();
+            case Node\Expr\StaticPropertyFetch::class:
+                return new Expression\StaticPropertyFetch();
             case Node\Expr\ArrayDimFetch::class:
                 return new Expression\ArrayDimFetch();
             case Node\Expr\UnaryMinus::class:

--- a/src/Compiler/Expression/IncludeOp.php
+++ b/src/Compiler/Expression/IncludeOp.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace PHPSA\Compiler\Expression;
+
+use PHPSA\CompiledExpression;
+use PHPSA\Context;
+use PHPSA\Compiler\Expression;
+use PHPSA\Compiler\Expression\AbstractExpressionCompiler;
+
+class ExitOp extends AbstractExpressionCompiler
+{
+    protected $name = 'PhpParser\Node\Expr\Include_';
+
+    /**
+     * include {expr}, require {expr}
+     *
+     * @param \PhpParser\Node\Expr\Include_ $expr
+     * @param Context $context
+     * @return CompiledExpression
+     */
+    protected function compile($expr, Context $context)
+    {
+        $compiled = $context->getExpressionCompiler()->compile($expr->expr);
+
+        if ($compiled->isString()) {
+            return CompiledExpression::fromZvalValue(1);
+        }
+
+        return CompiledExpression::fromZvalValue(false);
+    }
+}

--- a/src/Compiler/Expression/IncludeOp.php
+++ b/src/Compiler/Expression/IncludeOp.php
@@ -7,7 +7,7 @@ use PHPSA\Context;
 use PHPSA\Compiler\Expression;
 use PHPSA\Compiler\Expression\AbstractExpressionCompiler;
 
-class ExitOp extends AbstractExpressionCompiler
+class IncludeOp extends AbstractExpressionCompiler
 {
     protected $name = 'PhpParser\Node\Expr\Include_';
 

--- a/src/Compiler/Expression/ShellExec.php
+++ b/src/Compiler/Expression/ShellExec.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PHPSA\Compiler\Expression;
+
+use PHPSA\CompiledExpression;
+use PHPSA\Context;
+use PHPSA\Compiler\Expression;
+use PHPSA\Compiler\Expression\AbstractExpressionCompiler;
+
+class ShellExec extends AbstractExpressionCompiler
+{
+    protected $name = 'PhpParser\Node\Expr\ShellExec';
+
+    /**
+     * `{expr}`
+     *
+     * @param \PhpParser\Node\Expr\ShellExec $expr
+     * @param Context $context
+     * @return CompiledExpression
+     */
+    protected function compile($expr, Context $context)
+    {
+        return CompiledExpression::fromZvalValue(null);
+    }
+}

--- a/src/Compiler/Expression/StaticPropertyFetch.php
+++ b/src/Compiler/Expression/StaticPropertyFetch.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * PHP Smart Analysis project 2015-2016
+ *
+ * @author Patsura Dmitry https://github.com/ovr <talk@dmtry.me>
+ */
+
+namespace PHPSA\Compiler\Expression;
+
+use PHPSA\CompiledExpression;
+use PHPSA\Context;
+use PHPSA\Definition\ClassDefinition;
+
+class StaticPropertyFetch extends AbstractExpressionCompiler
+{
+    protected $name = 'PhpParser\Node\Expr\StaticPropertyFetch';
+
+    /**
+     * {expr}::${expr};
+     *
+     * @param \PhpParser\Node\Expr\StaticPropertyFetch $expr
+     * @param Context $context
+     * @return CompiledExpression
+     */
+    protected function compile($expr, Context $context)
+    {
+        $expressionCompiler = $context->getExpressionCompiler();
+        $leftCE = $expressionCompiler->compile($expr->class);
+
+        if ($leftCE->isObject()) {
+            $name = $expr->name;
+
+            /** @var ClassDefinition $classDefinition */
+            $classDefinition = $context->scope;
+            if (!$classDefinition->hasProperty($name, true)) {
+                $context->notice(
+                    'undefined-scall',
+                    sprintf('Static property $%s does not exist in %s scope', $name, $expr->class),
+                    $expr
+                );
+
+                return new CompiledExpression();
+            }
+
+            $property = $classDefinition->getPropertyStatement($name, true);
+            if (!$property->isStatic()) {
+                $context->notice(
+                    'undefined-scall',
+                    sprintf('Property $%s is not static but was called in a static way', $name),
+                    $expr
+                );
+            }
+
+            return $expressionCompiler->compile($property);
+        }
+
+        $context->debug('Unknown static property fetch', $expr);
+        return new CompiledExpression();
+    }
+}

--- a/src/Compiler/Expression/YieldFrom.php
+++ b/src/Compiler/Expression/YieldFrom.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace PHPSA\Compiler\Expression;
+
+use PHPSA\CompiledExpression;
+use PHPSA\Context;
+use PHPSA\Compiler\Expression;
+use PHPSA\Compiler\Expression\AbstractExpressionCompiler;
+
+class YieldFrom extends AbstractExpressionCompiler
+{
+    protected $name = 'PhpParser\Node\Expr\YieldFrom';
+
+    /**
+     * yield from {expr}
+     *
+     * @param \PhpParser\Node\Expr\YieldFrom $expr
+     * @param Context $context
+     * @return CompiledExpression
+     */
+    protected function compile($expr, Context $context)
+    {
+        $compiled = $context->getExpressionCompiler()->compile($expr->expr);
+
+        // @TODO implement yield from
+        return new CompiledExpression();
+    }
+}

--- a/src/Compiler/Expression/YieldOp.php
+++ b/src/Compiler/Expression/YieldOp.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace PHPSA\Compiler\Expression;
+
+use PHPSA\CompiledExpression;
+use PHPSA\Context;
+use PHPSA\Compiler\Expression;
+use PHPSA\Compiler\Expression\AbstractExpressionCompiler;
+
+class YieldOp extends AbstractExpressionCompiler
+{
+    protected $name = 'PhpParser\Node\Expr\Yield_';
+
+    /**
+     * yield {value}, yield {key} => {value}
+     *
+     * @param \PhpParser\Node\Expr\Yield_ $expr
+     * @param Context $context
+     * @return CompiledExpression
+     */
+    protected function compile($expr, Context $context)
+    {
+        $key = $context->getExpressionCompiler()->compile($expr->key);
+        $value = $context->getExpressionCompiler()->compile($expr->value);
+
+        // @TODO implement yield
+        return new CompiledExpression();
+    }
+}

--- a/src/Definition/ClassDefinition.php
+++ b/src/Definition/ClassDefinition.php
@@ -119,7 +119,7 @@ class ClassDefinition extends ParentDefinition
             $this->properties[$propertyDefinition->name] = $propertyDefinition;
         }
 
-        $this->propertyStatements[] = $property;
+        $this->propertyStatements[$propertyDefinition->name] = $property;
     }
 
     /**
@@ -290,7 +290,7 @@ class ClassDefinition extends ParentDefinition
     /**
      * @param string $name
      * @param bool $inherit
-     * @return Node\Stmt\Property
+     * @return Node\Stmt\PropertyProperty
      */
     public function getProperty($name, $inherit = false)
     {
@@ -302,6 +302,24 @@ class ClassDefinition extends ParentDefinition
 
         if ($inherit && $this->extendsClassDefinition) {
             return $this->extendsClassDefinition->getProperty($name, true);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string $name
+     * @param bool $inherit
+     * @return Node\Stmt\Property
+     */
+    public function getPropertyStatement($name, $inherit = false)
+    {
+        if (isset($this->propertyStatements[$name])) {
+            return $this->propertyStatements[$name];
+        }
+
+        if ($inherit && $this->extendsClassDefinition) {
+            return $this->extendsClassDefinition->getPropertyStatement($name, true);
         }
 
         return null;


### PR DESCRIPTION
Hey!

Type: new feature

Link to issue: Resolves #121 

This pull request affects the following components **(please check boxes):**

* [x] Core
* [ ] Analyzer
* [x] Compiler
* [ ] Control Flow Graph
* [ ] Documentation

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/ovr/phpsa/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

With this the compiler supports: include (and require), backtick (shell execution operator), yield and yield from (return only unknown, i'm not sure how to handle it at the moment), StaticPropertyFetch

with this the compiler has basic support for every node :+1: except: Node\Scalar\Encapsed