### PR TITLE
Fix VariableVariable analyzer

### DIFF
--- a/src/Analyzer/Pass/Expression/VariableVariableUsage.php
+++ b/src/Analyzer/Pass/Expression/VariableVariableUsage.php
@@ -40,6 +40,7 @@ class VariableVariableUsage implements Pass\AnalyzerPassInterface, Pass\Configur
             return $this->analyzeList($expr->var, $context);
         }
 
+        // $a = ... or class::$a =
         return $this->analyzeVar($expr->var, $context);
     }
 
@@ -88,7 +89,12 @@ class VariableVariableUsage implements Pass\AnalyzerPassInterface, Pass\Configur
         return false;
     }
 
-    private function analyzeVar(Expr\Variable $var, Context $context)
+
+    /**
+     * @param Expr\Variable|Expr\StaticPropertyFetch $var
+     * @param Context $context
+     */
+    private function analyzeVar(Expr $var, Context $context)
     {
         if (!$var->name instanceof Expr\Variable) {
             return false;

--- a/tests/analyze-fixtures/Expression/VariableVariableUsage.php
+++ b/tests/analyze-fixtures/Expression/VariableVariableUsage.php
@@ -4,6 +4,8 @@ namespace Tests\Analyze\Fixtures\Expression;
 
 class VariableVariableUsage
 {
+    public static $staticVar = 'notfoo';
+
     /**
      * @return string
      */
@@ -106,6 +108,24 @@ class VariableVariableUsage
 
         $this->{$varName}[] = 'foo';
     }
+
+    /**
+     * @return void
+     */
+    public function variableStaticPropertyAccessIsDiscouraged()
+    {
+        $varName = 'staticVar';
+
+        self::${$varName} = 'foo';
+    }
+
+    /**
+     * @return void
+     */
+    public function staticPropertyAccessIsOk()
+    {
+        self::$staticVar = 'foo';
+    }
 }
 ?>
 ----------------------------
@@ -114,30 +134,36 @@ class VariableVariableUsage
         "type": "variable.dynamic_assignment",
         "message": "Dynamic assignment is greatly discouraged.",
         "file": "VariableVariableUsage.php",
-        "line": 23
+        "line": 25
     },
     {
         "type": "variable.dynamic_assignment",
         "message": "Dynamic assignment is greatly discouraged.",
         "file": "VariableVariableUsage.php",
-        "line": 47
+        "line": 49
     },
     {
         "type": "variable.dynamic_assignment",
         "message": "Dynamic assignment is greatly discouraged.",
         "file": "VariableVariableUsage.php",
-        "line": 68
+        "line": 70
     },
     {
         "type": "variable.dynamic_assignment",
         "message": "Dynamic assignment is greatly discouraged.",
         "file": "VariableVariableUsage.php",
-        "line": 88
+        "line": 90
     },
     {
         "type": "variable.dynamic_assignment",
         "message": "Dynamic assignment is greatly discouraged.",
         "file": "VariableVariableUsage.php",
-        "line": 106
+        "line": 108
+    },
+    {
+        "type": "variable.dynamic_assignment",
+        "message": "Dynamic assignment is greatly discouraged.",
+        "file": "VariableVariableUsage.php",
+        "line": 118
     }
 ]


### PR DESCRIPTION
Hey!

Type: bug fix

Link to issue:

This pull request affects the following components **(please check boxes):**

* [ ] Core
* [x] Analyzer
* [ ] Compiler
* [ ] Control Flow Graph
* [ ] Documentation

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/ovr/phpsa/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

With the addition of staticPropertyFetch compiler the varvar analyzer broke. This fixes it.
