### PR TITLE
add analyzer for static variable scoping

### DIFF
--- a/src/Analyzer/Factory.php
+++ b/src/Analyzer/Factory.php
@@ -60,6 +60,7 @@ class Factory
                 new AnalyzerPass\Statement\ConstantNaming(),
                 new AnalyzerPass\Statement\InlineHtmlUsage(),
                 new AnalyzerPass\Statement\AssignmentInCondition(),
+                new AnalyzerPass\Statement\StaticUsage(),
             ]
         );
         $analyzer->bind();

--- a/src/Analyzer/Pass/Statement/StaticUsage.php
+++ b/src/Analyzer/Pass/Statement/StaticUsage.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace PHPSA\Analyzer\Pass\Statement;
+
+use PhpParser\Node\Stmt\Static_;
+use PHPSA\Analyzer\Pass;
+use PHPSA\Context;
+
+class StaticUsage implements Pass\AnalyzerPassInterface
+{
+    /**
+     * @param Static_ $stmt
+     * @param Context $context
+     *
+     * @return bool
+     */
+    public function pass(Static_ $stmt, Context $context)
+    {
+        $context->notice(
+            'static_usage',
+            'Do not use static variable scoping',
+            $stmt
+        );
+
+        return true;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRegister()
+    {
+        return [
+            Static_::class,
+        ];
+    }
+}

--- a/tests/PHPSA/AnalyzeFixturesTest.php
+++ b/tests/PHPSA/AnalyzeFixturesTest.php
@@ -102,14 +102,14 @@ class AnalyzeFixturesTest extends TestCase
             },
             $application->getIssuesCollector()->getIssues()
         );
-
+        
         foreach ($expectedArray as $check) {
-            self::assertEquals(in_array($check, $issues), true, $file); // every expected Issue is in the collector
+            self::assertContains($check, $issues, $file); // every expected Issue is in the collector
         }
 
         foreach ($issues as $check) {
             if ($check["type"] == $expectedType) {
-                self::assertEquals(in_array($check, $expectedArray), true, $file); // there is no other issue in the collector with the same type
+                self::assertContains($check, $expectedArray, $file); // there is no other issue in the collector with the same type
             }
         }
     }

--- a/tests/analyze-fixtures/Statement/StaticUsage.php
+++ b/tests/analyze-fixtures/Statement/StaticUsage.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Analyze\Fixtures\Statement;
+
+$a = 1;
+
+class StaticUsage
+{
+    public function testStatic()
+    {
+        $a = 4;
+
+        static $a;
+    }
+
+    public function testNoStatic()
+    {
+        $a = 2;
+
+        return $a * 3;
+    }
+}
+?>
+----------------------------
+[
+    {
+        "type": "static_usage",
+        "message": "Do not use static variable scoping",
+        "file": "StaticUsage.php",
+        "line": 12
+    }
+]


### PR DESCRIPTION
Hey!

Type: new feature

Link to issue: https://github.com/ovr/phpsa/issues/215

This pull request affects the following components **(please check boxes):**

* [ ] Core
* [x] Analyzer
* [ ] Compiler
* [ ] Control Flow Graph
* [ ] Documentation

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/ovr/phpsa/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

As suggested in issue https://github.com/ovr/phpsa/issues/215 I added an Analyser for static variable scoping usages.

Thanks

