### PR TITLE
Add analyzer for fixed value conditions

### DIFF
--- a/src/Analyzer/Factory.php
+++ b/src/Analyzer/Factory.php
@@ -60,6 +60,7 @@ class Factory
                 new AnalyzerPass\Statement\ConstantNaming(),
                 new AnalyzerPass\Statement\InlineHtmlUsage(),
                 new AnalyzerPass\Statement\AssignmentInCondition(),
+                new AnalyzerPass\Statement\FixedCondition(),
                 new AnalyzerPass\Statement\StaticUsage(),
             ]
         );

--- a/src/Analyzer/Pass/Statement/FixedCondition.php
+++ b/src/Analyzer/Pass/Statement/FixedCondition.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @author Christian Kraus <hanzi@hanzi.cc>
+ */
+
+namespace PHPSA\Analyzer\Pass\Statement;
+
+use PhpParser\Node\Stmt\Do_;
+use PhpParser\Node\Stmt\If_;
+use PhpParser\Node\Stmt\Switch_;
+use PhpParser\Node\Stmt\While_;
+use PHPSA\Analyzer\Pass;
+use PHPSA\Context;
+
+class FixedCondition implements Pass\AnalyzerPassInterface
+{
+    /**
+     * @param $stmt
+     * @param Context $context
+     * @return bool
+     */
+    public function pass($stmt, Context $context)
+    {
+        $result = false;
+        $expression = $context->getExpressionCompiler()->compile($stmt->cond);
+
+        if ($expression->hasValue()) {
+            $context->notice(
+                'fixed_condition',
+                'The condition will always result in the same boolean value',
+                $stmt
+            );
+
+            $result = true;
+        }
+
+        if ($stmt instanceof If_) {
+            foreach ($stmt->elseifs as $elseif) {
+                $result = $this->pass($elseif, $context) || $result;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRegister()
+    {
+        return [
+            If_::class,
+            While_::class,
+            Do_::class,
+            Switch_::class,
+        ];
+    }
+}

--- a/tests/analyze-fixtures/Statement/FixedCondition.php
+++ b/tests/analyze-fixtures/Statement/FixedCondition.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Tests\Analyze\Fixtures\Statement;
+
+class FixedCondition
+{
+
+    public function testInfiniteLoop()
+    {
+        $condition = new \stdClass;
+
+        while ($condition) {
+            return;
+        }
+    }
+
+
+    public function testInfiniteDoLoop()
+    {
+        do {
+            return;
+        } while (1);
+    }
+
+
+    public function testFixedIf()
+    {
+        if (5 - 5) {
+            return;
+        }
+    }
+
+
+    public function testFixedElseIf()
+    {
+        if ($this->dynamicValue()) {
+            return;
+        } elseif ('foo' == 'bar') {
+            return;
+        }
+    }
+
+
+    public function testFixedElseSpaceIf()
+    {
+        if ($this->dynamicValue()) {
+            return;
+        } else if (0.123) {
+            return;
+        }
+    }
+
+
+    public function testFixedSwitch()
+    {
+        switch (13) {
+            case 10:
+                return;
+
+            case 20:
+                return;
+        }
+    }
+
+
+    public function testDynamicIf()
+    {
+        if ($this->dynamicValue()) {
+            return;
+        }
+    }
+
+
+    private function dynamicValue()
+    {
+        return phpversion();
+    }
+}
+
+?>
+----------------------------
+[
+    {
+        "type": "fixed_condition",
+        "message": "The condition will always result in the same boolean value",
+        "file": "FixedCondition.php",
+        "line": 11
+    },
+    {
+        "type": "fixed_condition",
+        "message": "The condition will always result in the same boolean value",
+        "file": "FixedCondition.php",
+        "line": 19
+    },
+    {
+        "type": "fixed_condition",
+        "message": "The condition will always result in the same boolean value",
+        "file": "FixedCondition.php",
+        "line": 27
+    },
+    {
+        "type": "fixed_condition",
+        "message": "The condition will always result in the same boolean value",
+        "file": "FixedCondition.php",
+        "line": 37
+    },
+    {
+        "type": "fixed_condition",
+        "message": "The condition will always result in the same boolean value",
+        "file": "FixedCondition.php",
+        "line": 47
+    },
+    {
+        "type": "fixed_condition",
+        "message": "The condition will always result in the same boolean value",
+        "file": "FixedCondition.php",
+        "line": 55
+    }
+]


### PR DESCRIPTION
Hey!

Type: new feature

Link to issue: fix #218 

This pull request affects the following components **(please check boxes):**

* [ ] Core
* [x] Analyzer
* [ ] Compiler
* [ ] Control Flow Graph
* [ ] Documentation

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/ovr/phpsa/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Adds a new Analyzer that raises a notice if an `if`/`elseif`/`while`/`do`/`switch` condition has a predictable value.

Thanks

