### PR TITLE
Add analyzer for optional parameter before required one

### DIFF
--- a/src/Analyzer/Factory.php
+++ b/src/Analyzer/Factory.php
@@ -61,6 +61,7 @@ class Factory
                 new AnalyzerPass\Statement\InlineHtmlUsage(),
                 new AnalyzerPass\Statement\AssignmentInCondition(),
                 new AnalyzerPass\Statement\StaticUsage(),
+                new AnalyzerPass\Statement\OptionalParamBeforeRequired(),
             ]
         );
         $analyzer->bind();

--- a/src/Analyzer/Pass/Statement/OptionalParamBeforeRequired.php
+++ b/src/Analyzer/Pass/Statement/OptionalParamBeforeRequired.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @author Medvedev Alexandr https://github.com/lexty <alexandr.mdr@gmail.com>
+ */
+namespace PHPSA\Analyzer\Pass\Statement;
+
+use PhpParser\Node\Stmt;
+use PHPSA\Analyzer\Pass;
+use PHPSA\Context;
+
+class OptionalParamBeforeRequired implements Pass\AnalyzerPassInterface
+{
+    /**
+     * @param Stmt $func
+     * @param Context $context
+     * @return bool
+     */
+    public function pass(Stmt $func, Context $context)
+    {
+        $prevIsOptional = false;
+        foreach ($func->getParams() as $param) {
+            if ($prevIsOptional && $param->default === null) {
+                $context->notice('optional-param-before-required', 'Optional parameter before required one is always required.', $func);
+                return true;
+            }
+            $prevIsOptional = $param->default !== null;
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRegister()
+    {
+        return [
+            Stmt\Function_::class,
+            Stmt\ClassMethod::class,
+        ];
+    }
+}

--- a/tests/analyze-fixtures/Statement/OptionalParamBeforeRequired.php
+++ b/tests/analyze-fixtures/Statement/OptionalParamBeforeRequired.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @author Medvedev Alexandr https://github.com/lexty <alexandr.mdr@gmail.com>
+ */
+namespace Tests\Analyze\Fixtures\Statement;
+
+function OptionalParamBeforeRequiredFunction($a = 1, $b)
+{}
+
+class OptionalParamBeforeRequiredClass
+{
+    public function OptionalParamBeforeRequiredMethod($a = 1, $b)
+    {}
+};
+
+function OptionalParamAfterRequiredFunction($a, $b = 1)
+{}
+
+class OptionalParamAfterRequiredClass
+{
+    public function OptionalParamAfterRequiredMethod($a, $b = 1)
+    {}
+}
+
+?>
+----------------------------
+[
+    {
+        "type":"optional-param-before-required",
+        "message":"Optional parameter before required one is always required.",
+        "file":"OptionalParamBeforeRequired.php",
+        "line":7
+    },
+    {
+        "type":"optional-param-before-required",
+        "message":"Optional parameter before required one is always required.",
+        "file":"OptionalParamBeforeRequired.php",
+        "line":12
+    }
+]


### PR DESCRIPTION
Hey!

Type: new feature

Link to issue: fix #217 

This pull request affects the following components **(please check boxes):**

* [ ] Core
* [x] Analyzer
* [ ] Compiler
* [ ] Control Flow Graph
* [ ] Documentation

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/ovr/phpsa/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:
Adds a new Analyzer that raises a notice if any function or class method has optional parameter before required one.

Thanks

