### PR TITLE
[Analyzer] Return and Yield in one Method

### DIFF
--- a/.phpsa.yml
+++ b/.phpsa.yml
@@ -91,4 +91,6 @@ phpsa:
             enabled:              true
         yoda_condition:
             enabled:              true
+        return_and_yield_in_one_method:
+            enabled:              true
 

--- a/docs/05_Analyzers.md
+++ b/docs/05_Analyzers.md
@@ -36,7 +36,7 @@ Checks for casts that try to cast a type to itself.
 
 #### CompareWithArray
 
-Checks for `{type array} > 1` and similar and suggests use of `count()`. 
+Checks for `{type array} > 1` and similar and suggests use of `count()`.
 
 #### ConstantNaming
 
@@ -129,6 +129,10 @@ Checks for use of old rand, srand, getrandmax functions and suggests alternative
 #### RegularExpressions
 
 Checks that regular expressions are syntactically correct.
+
+#### ReturnAndYieldInOneMethod
+
+Checks for using return and yield statements in a one method and discourages it.
 
 #### StaticUsage
 

--- a/src/Analyzer/Factory.php
+++ b/src/Analyzer/Factory.php
@@ -97,6 +97,7 @@ class Factory
             AnalyzerPass\Statement\StaticUsage::class,
             AnalyzerPass\Statement\OptionalParamBeforeRequired::class,
             AnalyzerPass\Statement\YodaCondition::class,
+            AnalyzerPass\Statement\ReturnAndYieldInOneMethod::class,
         ];
     }
 

--- a/src/Analyzer/Helper/ResolveExpressionTrait.php
+++ b/src/Analyzer/Helper/ResolveExpressionTrait.php
@@ -34,16 +34,28 @@ trait ResolveExpressionTrait
     }
 
     /**
+     * Finds statements of the given class name.
+     *
+     * @param \PhpParser\Node[] $nodes
+     * @param string $stmtClass
+     * @return \PhpParser\Node\Stmt
+     */
+    protected function findStatement(array $nodes, $stmtClass)
+    {
+        foreach ($this->traverseArray($nodes) as $node) {
+            if ($node instanceof $stmtClass) {
+                yield $node;
+            }
+        }
+    }
+
+    /**
      * @param \PhpParser\Node[] $nodes
      * @return \PhpParser\Node\Stmt\Return_
      */
     protected function findReturnStatement(array $nodes)
     {
-        foreach ($this->traverseArray($nodes) as $node) {
-            if ($node instanceof Return_) {
-                yield $node;
-            }
-        }
+        return $this->findStatement($nodes, Return_::class);
     }
 
     /**

--- a/src/Analyzer/Pass/Statement/ReturnAndYieldInOneMethod.php
+++ b/src/Analyzer/Pass/Statement/ReturnAndYieldInOneMethod.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace PHPSA\Analyzer\Pass\Statement;
+
+use PhpParser\Node\Expr\Yield_;
+use PhpParser\Node\Stmt;
+use PHPSA\Analyzer\Helper\DefaultMetadataPassTrait;
+use PHPSA\Analyzer\Helper\ResolveExpressionTrait;
+use PHPSA\Analyzer\Pass;
+use PHPSA\Context;
+
+class ReturnAndYieldInOneMethod implements Pass\AnalyzerPassInterface
+{
+    use DefaultMetadataPassTrait,
+        ResolveExpressionTrait;
+
+    /**
+     * @param Stmt $stmt
+     * @param Context $context
+     * @return bool
+     */
+    public function pass(Stmt $stmt, Context $context)
+    {
+        if ($this->returnStatementExists($stmt) && $this->yieldStatementExists($stmt)) {
+            $context->notice('return_and_yield_in_one_method', 'Do not use return and yield in a one method', $stmt);
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param Stmt $node
+     *
+     * @return bool
+     */
+    private function returnStatementExists(Stmt $node)
+    {
+        return (bool)$this->findReturnStatement([$node])->current();
+    }
+
+    /**
+     * @param Stmt $node
+     *
+     * @return bool
+     */
+    private function yieldStatementExists(Stmt $node)
+    {
+        return (bool)$this->findStatement([$node], Yield_::class)->current();
+    }
+
+    /**
+     * @return array
+     */
+    public function getRegister()
+    {
+        return [
+            Stmt\ClassMethod::class,
+        ];
+    }
+}

--- a/tests/analyze-fixtures/Statement/ReturnAndYieldInOneMethod.php
+++ b/tests/analyze-fixtures/Statement/ReturnAndYieldInOneMethod.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Analyze\Fixtures\Statement;
+
+class ReturnAndYieldInOneMethod
+{
+    public function testReturnAndYield($a = true)
+    {
+        if ($a) {
+            return $a;
+        }
+        yield $a;
+    }
+
+    public function testReturnOnly($a = true)
+    {
+        if ($a) {
+            return $a;
+        }
+        return !$a;
+    }
+
+    public function testYieldOnly($a = true)
+    {
+        if ($a) {
+            yield $a;
+        }
+    }
+
+    public function testVoid(&$a)
+    {
+        $a = false;
+    }
+}
+?>
+----------------------------
+[
+    {
+        "type": "return_and_yield_in_one_method",
+        "message": "Do not use return and yield in a one method",
+        "file": "ReturnAndYieldInOneMethod.php",
+        "line": 6
+    }
+]


### PR DESCRIPTION
Hey!

Type: new feature

Link to issue: #185 

This pull request affects the following components **(please check boxes):**
- [ ] Core
- [x] Analyzer
- [ ] Compiler
- [ ] Control Flow Graph
- [x] Documentation

**In raising this pull request, I confirm the following (please check boxes):**
- [x] I have read and understood the [Contributing Guidelines](https://github.com/ovr/phpsa/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:
Adds a new Analyzer that raises a notice for using return and yield statements in a one method.
Also there are small changes in `PHPSA\Analyzer\Helper\ResolveExpressionTrait` (added `findStatement` method and changed `findReturnStatement` method).

This is my last PR for the `hacktoberfest` label. Next will try something else.
Thanks.
