### PR TITLE
Add analyzer descriptions

### DIFF
--- a/docs/05_Analyzers.md
+++ b/docs/05_Analyzers.md
@@ -12,7 +12,8 @@ Checks for use of `func_get_args()` and suggests the use of argument unpacking. 
 
 #### ArrayDuplicateKeys
 
-Checks for duplicate array keys on definition. Can handle variable keys.
+This inspection reports any duplicated keys on array creation expression.
+If multiple elements in the array declaration use the same key, only the last one will be used as all others are overwritten.
 
 #### ArrayIllegalOffsetType
 
@@ -36,7 +37,7 @@ Checks for casts that try to cast a type to itself.
 
 #### CompareWithArray
 
-Checks for `{type array} > 1` and similar and suggests use of `count()`. 
+Checks for `{type array} > 1` and similar and suggests use of `count()`.
 
 #### ConstantNaming
 
@@ -56,7 +57,7 @@ Checks for use of deprecated php.ini options and gives alternatives if available
 
 #### ErrorSuppression
 
-Discourages the use of @ operator to silence errors.
+Discourages the use of the `@` operator to silence errors.
 
 #### EvalUsage
 
@@ -68,7 +69,7 @@ Discourages the use of `exit()` and `die()`.
 
 #### FinalStaticUsage
 
-Checks for use of static:: inside a final class.
+Checks for use of `static::` inside a final class.
 
 #### GlobalUsage
 
@@ -85,6 +86,10 @@ Checks for multiple property definitions in one line. For example public $a, $b;
 #### InlineHtmlUsage
 
 Discourages the use of inline html.
+
+#### LogicInversion
+
+Checks for Logic inversion like `if (!($a == $b))` and suggests the correct operator.
 
 #### MagicMethodParameters
 

--- a/src/Analyzer/Pass/Expression/ArrayIllegalOffsetType.php
+++ b/src/Analyzer/Pass/Expression/ArrayIllegalOffsetType.php
@@ -14,6 +14,8 @@ class ArrayIllegalOffsetType implements AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Checks for illegal array key types (for example objects).';
+
     /**
      * @param Expr\Array_|Expr\Assign $expr
      * @param Context $context

--- a/src/Analyzer/Pass/Expression/ArrayShortDefinition.php
+++ b/src/Analyzer/Pass/Expression/ArrayShortDefinition.php
@@ -16,7 +16,7 @@ class ArrayShortDefinition implements AnalyzerPassInterface
         DefaultMetadataPassTrait::getMetadata as defaultMetadata;
     }
 
-    const DESCRIPTION = 'Short syntax can be used in array literals.';
+    const DESCRIPTION = 'Recommends the use of [] short syntax for arrays.';
 
     /**
      * @param Expr\Array_ $expr

--- a/src/Analyzer/Pass/Expression/BacktickUsage.php
+++ b/src/Analyzer/Pass/Expression/BacktickUsage.php
@@ -11,6 +11,8 @@ class BacktickUsage implements AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Discourages the use of backtick operator for shell execution.';
+
     /**
      * @param Expr\ShellExec $expr
      * @param Context $context

--- a/src/Analyzer/Pass/Expression/Casts.php
+++ b/src/Analyzer/Pass/Expression/Casts.php
@@ -12,6 +12,8 @@ class Casts implements AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Checks for casts that try to cast a type to itself.';
+
     /**
      * @param Expr $expr
      * @param Context $context

--- a/src/Analyzer/Pass/Expression/CompareWithArray.php
+++ b/src/Analyzer/Pass/Expression/CompareWithArray.php
@@ -11,6 +11,8 @@ class CompareWithArray implements AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Checks for `{type array} > 1` and similar and suggests use of `count()`.';
+
     /**
      * @param Expr $expr
      * @param Context $context

--- a/src/Analyzer/Pass/Expression/ErrorSuppression.php
+++ b/src/Analyzer/Pass/Expression/ErrorSuppression.php
@@ -11,6 +11,8 @@ class ErrorSuppression implements AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Discourages the use of the `@` operator to silence errors.';
+
     /**
      * @param Expr\ErrorSuppress $expr
      * @param Context $context

--- a/src/Analyzer/Pass/Expression/EvalUsage.php
+++ b/src/Analyzer/Pass/Expression/EvalUsage.php
@@ -14,6 +14,8 @@ class EvalUsage implements AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Discourages the use of `eval()`.';
+
     /**
      * @param Expr\Eval_ $expr
      * @param Context $context

--- a/src/Analyzer/Pass/Expression/ExitUsage.php
+++ b/src/Analyzer/Pass/Expression/ExitUsage.php
@@ -14,6 +14,8 @@ class ExitUsage implements Pass\AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Discourages the use of `exit()` and `die()`.';
+
     /**
      * @param Expr\Exit_ $expr
      * @param Context $context

--- a/src/Analyzer/Pass/Expression/FinalStaticUsage.php
+++ b/src/Analyzer/Pass/Expression/FinalStaticUsage.php
@@ -10,7 +10,11 @@ use PHPSA\Definition\ClassDefinition;
 
 class FinalStaticUsage implements AnalyzerPassInterface
 {
-    use DefaultMetadataPassTrait;
+    use DefaultMetadataPassTrait {
+        DefaultMetadataPassTrait::getMetadata as defaultMetadata;
+    }
+
+    const DESCRIPTION = 'Checks for use of `static::` inside a final class.';
 
     /**
      * @param Expr\StaticCall $expr
@@ -45,5 +49,16 @@ class FinalStaticUsage implements AnalyzerPassInterface
         return [
             Expr\StaticCall::class,
         ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getMetadata()
+    {
+        $metadata = self::defaultMetadata();
+        $metadata->setRequiredPhpVersion('5.3'); //static:: since PHP 5.3
+
+        return $metadata;
     }
 }

--- a/src/Analyzer/Pass/Expression/FunctionCall/AliasCheck.php
+++ b/src/Analyzer/Pass/Expression/FunctionCall/AliasCheck.php
@@ -10,6 +10,8 @@ use PHPSA\Context;
 
 class AliasCheck extends AbstractFunctionCallAnalyzer
 {
+    const DESCRIPTION = 'Checks for use of alias functions and suggests the use of the originals.';
+
     protected $map = [
         'join' => 'implode',
         'sizeof' => 'count',

--- a/src/Analyzer/Pass/Expression/FunctionCall/ArgumentUnpacking.php
+++ b/src/Analyzer/Pass/Expression/FunctionCall/ArgumentUnpacking.php
@@ -9,6 +9,8 @@ use PHPSA\Definition\FunctionDefinition;
 
 class ArgumentUnpacking extends AbstractFunctionCallAnalyzer
 {
+    const DESCRIPTION = 'Checks for use of `func_get_args()` and suggests the use of argument unpacking. (... operator)';
+
     public function pass(FuncCall $funcCall, Context $context)
     {
         $functionName = $this->resolveFunctionName($funcCall, $context);

--- a/src/Analyzer/Pass/Expression/FunctionCall/DebugCode.php
+++ b/src/Analyzer/Pass/Expression/FunctionCall/DebugCode.php
@@ -11,6 +11,8 @@ use PHPSA\Context;
 
 class DebugCode extends AbstractFunctionCallAnalyzer
 {
+    const DESCRIPTION = 'Checks for use of debug code and suggests to remove it.';
+
     protected $map = [
         'var_dump' => 'var_dump',
         'var_export' => 'var_export',

--- a/src/Analyzer/Pass/Expression/FunctionCall/DeprecatedFunctions.php
+++ b/src/Analyzer/Pass/Expression/FunctionCall/DeprecatedFunctions.php
@@ -7,6 +7,8 @@ use PHPSA\Context;
 
 class DeprecatedFunctions extends AbstractFunctionCallAnalyzer
 {
+    const DESCRIPTION = 'Checks for use of deprecated functions and gives alternatives if available.';
+
     protected $map = [
         'datefmt_set_timezone_id' => ['5.5','IntlDateFormatter::setTimeZone()'],
         'define_syslog_variables' => ['5.3','_'],

--- a/src/Analyzer/Pass/Expression/FunctionCall/DeprecatedIniOptions.php
+++ b/src/Analyzer/Pass/Expression/FunctionCall/DeprecatedIniOptions.php
@@ -10,6 +10,8 @@ use PHPSA\Context;
 
 class DeprecatedIniOptions extends AbstractFunctionCallAnalyzer
 {
+    const DESCRIPTION = 'Checks for use of deprecated php.ini options and gives alternatives if available.';
+
     static protected $functions = [
         'ini_set' => 'ini_set',
         'ini_get' => 'ini_get',

--- a/src/Analyzer/Pass/Expression/FunctionCall/RandomApiMigration.php
+++ b/src/Analyzer/Pass/Expression/FunctionCall/RandomApiMigration.php
@@ -10,6 +10,8 @@ use PHPSA\Context;
 
 class RandomApiMigration extends AbstractFunctionCallAnalyzer
 {
+    const DESCRIPTION = 'Checks for use of old rand, srand, getrandmax functions and suggests alternatives.';
+
     protected $map = [
         'rand' => 'mt_rand',
         'srand' => 'mt_srand',

--- a/src/Analyzer/Pass/Expression/FunctionCall/RegularExpressions.php
+++ b/src/Analyzer/Pass/Expression/FunctionCall/RegularExpressions.php
@@ -12,6 +12,8 @@ use PHPSA\Context;
 
 class RegularExpressions extends AbstractFunctionCallAnalyzer
 {
+    const DESCRIPTION = 'Checks that regular expressions are syntactically correct.';
+
     static public $map = [
         'preg_filter' => 0,
         'preg_grep' => 0,

--- a/src/Analyzer/Pass/Expression/FunctionCall/UseCast.php
+++ b/src/Analyzer/Pass/Expression/FunctionCall/UseCast.php
@@ -10,6 +10,8 @@ use PHPSA\Context;
 
 class UseCast extends AbstractFunctionCallAnalyzer
 {
+    const DESCRIPTION = 'Checks for use of functions like boolval, strval and others and suggests the use of casts.';
+
     protected $map = [
         'boolval' => 'bool',
         'intval' => 'int',

--- a/src/Analyzer/Pass/Expression/LogicInversion.php
+++ b/src/Analyzer/Pass/Expression/LogicInversion.php
@@ -14,6 +14,8 @@ class LogicInversion implements AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Checks for Logic inversion like `if (!($a == $b))` and suggests the correct operator.';
+
     protected $map = [
         'Expr_BinaryOp_Equal' => ['!=', '=='],
         'Expr_BinaryOp_NotEqual' => ['==', '!='],

--- a/src/Analyzer/Pass/Expression/MultipleUnaryOperators.php
+++ b/src/Analyzer/Pass/Expression/MultipleUnaryOperators.php
@@ -11,6 +11,8 @@ class MultipleUnaryOperators implements AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Checks for use of multiple unary operators that cancel each other out. For example `!!boolean` or `- -int`. (there is a space between the two minus)';
+
     /**
      * @param Expr $expr
      * @param Context $context

--- a/src/Analyzer/Pass/Expression/StupidUnaryOperators.php
+++ b/src/Analyzer/Pass/Expression/StupidUnaryOperators.php
@@ -11,6 +11,8 @@ class StupidUnaryOperators implements AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Checks for use of UnaryPlus `+$a` and suggests to use an int or float cast instead.';
+
     /**
      * @param Expr $expr
      * @param Context $context

--- a/src/Analyzer/Pass/Expression/VariableVariableUsage.php
+++ b/src/Analyzer/Pass/Expression/VariableVariableUsage.php
@@ -14,6 +14,8 @@ class VariableVariableUsage implements Pass\AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Discourages the use of variable variables.';
+
     /**
      * @param Expr\Assign $expr
      * @param Context $context

--- a/src/Analyzer/Pass/Statement/AssignmentInCondition.php
+++ b/src/Analyzer/Pass/Statement/AssignmentInCondition.php
@@ -22,6 +22,8 @@ class AssignmentInCondition implements Pass\AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Checks for assignments in conditions. (= instead of ==)';
+
     /**
      * @param $stmt
      * @param Context $context

--- a/src/Analyzer/Pass/Statement/ConstantNaming.php
+++ b/src/Analyzer/Pass/Statement/ConstantNaming.php
@@ -12,6 +12,8 @@ class ConstantNaming implements AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Checks that constants are all uppercase.';
+
     /**
      * @param ClassConst $stmt
      * @param Context $context

--- a/src/Analyzer/Pass/Statement/GlobalUsage.php
+++ b/src/Analyzer/Pass/Statement/GlobalUsage.php
@@ -13,6 +13,8 @@ class GlobalUsage implements Pass\AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Discourages the use of `global $var;`.';
+
     /**
      * @param $stmt
      * @param Context $context

--- a/src/Analyzer/Pass/Statement/GotoUsage.php
+++ b/src/Analyzer/Pass/Statement/GotoUsage.php
@@ -14,6 +14,8 @@ class GotoUsage implements Pass\AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Discourages the use of goto and goto labels.';
+
     /**
      * @param $stmt
      * @param Context $context

--- a/src/Analyzer/Pass/Statement/HasMoreThanOneProperty.php
+++ b/src/Analyzer/Pass/Statement/HasMoreThanOneProperty.php
@@ -13,6 +13,8 @@ class HasMoreThanOneProperty implements Pass\AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Checks for multiple property definitions in one line. For example public $a, $b; and discourages it.';
+
     /**
      * @param Property $prop
      * @param Context $context

--- a/src/Analyzer/Pass/Statement/InlineHtmlUsage.php
+++ b/src/Analyzer/Pass/Statement/InlineHtmlUsage.php
@@ -12,6 +12,8 @@ class InlineHtmlUsage implements Pass\AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Discourages the use of inline html.';
+
     /**
      * @param Stmt\InlineHTML $stmt
      * @param Context $context

--- a/src/Analyzer/Pass/Statement/MagicMethodParameters.php
+++ b/src/Analyzer/Pass/Statement/MagicMethodParameters.php
@@ -15,6 +15,8 @@ class MagicMethodParameters implements AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Checks that magic methods have the right amount of parameters.';
+
     /**
      * @param ClassMethod $methodStmt
      * @param Context $context

--- a/src/Analyzer/Pass/Statement/MethodCannotReturn.php
+++ b/src/Analyzer/Pass/Statement/MethodCannotReturn.php
@@ -16,6 +16,8 @@ class MethodCannotReturn implements Pass\AnalyzerPassInterface
     use DefaultMetadataPassTrait;
     use ResolveExpressionTrait;
 
+    const DESCRIPTION = 'Checks for return statements in `__construct` and `__destruct` since they can\'t return anything.';
+
     /**
      * @param ClassMethod $methodStmt
      * @param Context $context

--- a/src/Analyzer/Pass/Statement/MissingBody.php
+++ b/src/Analyzer/Pass/Statement/MissingBody.php
@@ -10,6 +10,8 @@ use PHPSA\Context;
 class MissingBody implements AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
+
+    const DESCRIPTION = 'Checks that statements that define a block of statements are not empty.';
     
     /**
      * @param Stmt $stmt

--- a/src/Analyzer/Pass/Statement/MissingBreakStatement.php
+++ b/src/Analyzer/Pass/Statement/MissingBreakStatement.php
@@ -14,6 +14,8 @@ class MissingBreakStatement implements Pass\AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Checks for a missing break or return statement in switch cases. Can ignore empty cases and the last case.';
+
     /**
      * @param Stmt\Switch_ $switchStmt
      * @param Context $context

--- a/src/Analyzer/Pass/Statement/MissingDocblock.php
+++ b/src/Analyzer/Pass/Statement/MissingDocblock.php
@@ -11,6 +11,8 @@ class MissingDocblock implements AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Checks for a missing docblock for: class, property, class constant, trait, interface, class method, function.';
+
     /**
      * @param Stmt $stmt
      * @param Context $context

--- a/src/Analyzer/Pass/Statement/MissingVisibility.php
+++ b/src/Analyzer/Pass/Statement/MissingVisibility.php
@@ -14,6 +14,8 @@ class MissingVisibility implements AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Checks for missing visibility modifiers for properties and methods.';
+
     /**
      * @param Stmt $stmt
      * @param Context $context

--- a/src/Analyzer/Pass/Statement/OldConstructor.php
+++ b/src/Analyzer/Pass/Statement/OldConstructor.php
@@ -11,6 +11,8 @@ class OldConstructor implements AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Checks for use of PHP 4 constructors and discourages it.';
+
     /**
      * @param Stmt\Class_ $classStmt
      * @param Context $context

--- a/src/Analyzer/Pass/Statement/OptionalParamBeforeRequired.php
+++ b/src/Analyzer/Pass/Statement/OptionalParamBeforeRequired.php
@@ -14,6 +14,8 @@ class OptionalParamBeforeRequired implements Pass\AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Checks if any optional parameters are before a required one. For example: `function ($a = 1, $b)`';
+
     /**
      * @param Stmt $func
      * @param Context $context

--- a/src/Analyzer/Pass/Statement/StaticUsage.php
+++ b/src/Analyzer/Pass/Statement/StaticUsage.php
@@ -11,6 +11,8 @@ class StaticUsage implements Pass\AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Discourages the use of static variables (not properties).';
+
     /**
      * @param Static_ $stmt
      * @param Context $context

--- a/src/Analyzer/Pass/Statement/TestAnnotation.php
+++ b/src/Analyzer/Pass/Statement/TestAnnotation.php
@@ -12,6 +12,8 @@ class TestAnnotation implements AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Checks for use of `@test` when methods name begins with test, since it is unnecessary.';
+
     /** @var DocBlockFactory */
     protected $docBlockFactory;
 

--- a/src/Analyzer/Pass/Statement/UnexpectedUseOfThis.php
+++ b/src/Analyzer/Pass/Statement/UnexpectedUseOfThis.php
@@ -15,6 +15,8 @@ class UnexpectedUseOfThis implements Pass\AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Checks for behavior that would result in overwriting $this variable.';
+
     /**
      * @param Node\Stmt $stmt
      * @param Context $context

--- a/src/Analyzer/Pass/Statement/YodaCondition.php
+++ b/src/Analyzer/Pass/Statement/YodaCondition.php
@@ -21,6 +21,8 @@ class YodaCondition implements Pass\AnalyzerPassInterface
 {
     use DefaultMetadataPassTrait;
 
+    const DESCRIPTION = 'Checks for Yoda conditions, where a constant is placed before the variable. For example: `if (3 == $a)`';
+
     /**
      * @param $stmt
      * @param Context $context


### PR DESCRIPTION
Hey!

Type: 

Link to issue: #234 

This pull request affects the following components **(please check boxes):**

* [ ] Core
* [x] Analyzer
* [ ] Compiler
* [ ] Control Flow Graph
* [x] Documentation

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/ovr/phpsa/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Added descriptions to analyzers, min php version for finalstatic analyzer, updated documentation.
Would be cool if dump-reference command could output the documentation file so we only have to update the texts once.
