### PR TITLE
MissingBody analyzer checks abstract

### DIFF
--- a/src/Analyzer/Pass/Statement/MissingBody.php
+++ b/src/Analyzer/Pass/Statement/MissingBody.php
@@ -20,6 +20,10 @@ class MissingBody implements AnalyzerPassInterface
      */
     public function pass(Stmt $stmt, Context $context)
     {
+        if ($stmt instanceof Stmt\ClassMethod && $stmt->isAbstract()) { // abstract classes are ok
+            return false;
+        }
+
         if ($stmt instanceof Stmt\Switch_) {
             $counting = $stmt->cases;
         } else {

--- a/tests/analyze-fixtures/Statement/MissingBody.php
+++ b/tests/analyze-fixtures/Statement/MissingBody.php
@@ -35,7 +35,7 @@ class MissingBody
 function missingBodyFunction() {
 }
 
-class ImplementedBody
+abstract class ImplementedBody
 {
     public function implementedBodyMethod() {
         echo "implemented";
@@ -73,6 +73,8 @@ class ImplementedBody
             echo "implemented";
         }
     }
+
+    abstract public function abstractFunc();
 }
 
 function implementedBodyFunction() {


### PR DESCRIPTION
Hey!

Type: bug fix

Link to issue:

This pull request affects the following components **(please check boxes):**

* [ ] Core
* [x] Analyzer
* [ ] Compiler
* [ ] Control Flow Graph
* [ ] Documentation

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/ovr/phpsa/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Missing Body analyzer gave awesome notices that abstract methods are without a body. Now it knows what abstract means. :+1: 

