### PR TITLE
Add Break/Continue language level errors

### DIFF
--- a/src/Compiler/Statement/BreakSt.php
+++ b/src/Compiler/Statement/BreakSt.php
@@ -4,6 +4,7 @@ namespace PHPSA\Compiler\Statement;
 
 use PHPSA\CompiledExpression;
 use PHPSA\Context;
+use PhpParser\Node\Scalar\LNumber;
 
 class BreakSt extends AbstractCompiler
 {
@@ -19,7 +20,15 @@ class BreakSt extends AbstractCompiler
         $compiler = $context->getExpressionCompiler();
 
         if ($stmt->num !== null) {
-            $compiler->compile($stmt->num);
+            $compiled = $compiler->compile($stmt->num);
+            
+            if (!($stmt->num instanceof LNumber) || $compiled->getValue() == 0) {
+                $context->notice(
+                    'language-error',
+                    'Break only supports positive integers.',
+                    $stmt
+                );
+            }
         }
     }
 }

--- a/src/Compiler/Statement/ContinueSt.php
+++ b/src/Compiler/Statement/ContinueSt.php
@@ -19,7 +19,15 @@ class ContinueSt extends AbstractCompiler
         $compiler = $context->getExpressionCompiler();
 
         if ($stmt->num !== null) {
-            $compiler->compile($stmt->num);
+            $compiled = $compiler->compile($stmt->num);
+
+            if (!($stmt->num instanceof LNumber) || $compiled->getValue() == 0) {
+                $context->notice(
+                    'language-error',
+                    'Continue only supports positive integers.',
+                    $stmt
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
Hey!

Type: new feature

Link to issue:

This pull request affects the following components **(please check boxes):**
- [ ] Core
- [ ] Analyzer
- [x] Compiler
- [ ] Control Flow Graph
- [ ] Documentation

**In raising this pull request, I confirm the following (please check boxes):**
- [x] I have read and understood the [Contributing Guidelines](https://github.com/ovr/phpsa/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Added language level errors for break, continue. Currently we only support syntax errors.
