### PR TITLE
Added dump-documentation command for analyzers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,11 @@ tests: tests-local
 tests-ci:
 	./vendor/bin/phpunit -v --debug --coverage-clover=coverage.clover
 
+# For renewing config and documentation when analyzers were changed
+analyzers:
+	./bin/phpsa config:dump-reference > .phpsa.yml	
+	./bin/phpsa config:dump-documentation > docs/05_Analyzers.md
+
 test: tests-local cs
 
 ci: cs tests-ci check-fixtures check-src

--- a/docs/05_Analyzers.md
+++ b/docs/05_Analyzers.md
@@ -1,190 +1,190 @@
 # Analyzers
-
 This doc gives an overview about what the different analyzers do.
 
-#### AliasCheck
-
-Checks for use of alias functions and suggests the use of the originals.
-
-#### ArgumentUnpacking
-
-Checks for use of `func_get_args()` and suggests the use of argument unpacking. (... operator)
-
-#### ArrayDuplicateKeys
-
-This inspection reports any duplicated keys on array creation expression.
-If multiple elements in the array declaration use the same key, only the last one will be used as all others are overwritten.
-
-#### ArrayIllegalOffsetType
-
-Checks for illegal array key types (for example objects).
-
-#### ArrayShortDefinition
-
-Recommends the use of [] short syntax for arrays.
-
-#### AssignmentInCondition
-
-Checks for assignments in conditions. (= instead of ==)
-
-#### BacktickUsage
-
-Discourages the use of backtick operator for shell execution.
-
-#### Casts
-
-Checks for casts that try to cast a type to itself.
-
-#### CheckLNumberKind
-
-Using octal, hexadecimal or binary integers is discouraged.
-
-#### CompareWithArray
-
-Checks for `{type array} > 1` and similar and suggests use of `count()`.
-
-#### ConstantNaming
-
-Checks that constants are all uppercase.
-
-#### DebugCode
-
-Checks for use of debug code and suggests to remove it.
-
-#### DeprecatedFunctions
-
-Checks for use of deprecated functions and gives alternatives if available.
-
-#### DeprecatedIniOptions
-
-Checks for use of deprecated php.ini options and gives alternatives if available.
-
-#### DivisionByOne
-
-Checks for division by 1. For example: `$x/1`, `$x%true`
-
-#### DivisionFromZero
-
-Checks for division from 0. For example: `0/$x`, `false%$x`
-
-#### ErrorSuppression
+#### error_suppression
 
 Discourages the use of the `@` operator to silence errors.
 
-#### EvalUsage
-
-Discourages the use of `eval()`.
-
-#### ExitUsage
-
-Discourages the use of `exit()` and `die()`.
-
-#### FinalStaticUsage
-
-Checks for use of `static::` inside a final class.
-
-#### ForCondition
-
-Discourages the use of `for` with multiple conditions.
-
-#### GlobalUsage
-
-Discourages the use of `global $var;`.
-
-#### GotoUsage
-
-Discourages the use of goto and goto labels.
-
-#### HasMoreThanOneProperty
-
-Checks for multiple property definitions in one line. For example public $a, $b; and discourages it.
-
-#### InlineHtmlUsage
-
-Discourages the use of inline html.
-
-#### LogicInversion
-
-Checks for Logic inversion like `if (!($a == $b))` and suggests the correct operator.
-
-#### MagicMethodParameters
-
-Checks that magic methods have the right amount of parameters.
-
-#### MethodCannotReturn
-
-Checks for return statements in `__construct` and `__destruct` since they can't return anything.
-
-#### MissingBody
-
-Checks that statements that define a block of statements are not empty.
-
-#### MissingBreakStatement
-
-Checks for a missing break or return statement in switch cases. Can ignore empty cases and the last case.
-
-#### MissingDocblock
-
-Checks for a missing docblock for: class, property, class constant, trait, interface, class method, function.
-
-#### MissingVisibility
-
-Checks for missing visibility modifiers for properties and methods.
-
-#### MultipleUnaryOperators
+#### multiple_unary_operators
 
 Checks for use of multiple unary operators that cancel each other out. For example `!!boolean` or `- -int`. (there is a space between the two minus)
 
-#### OldConstructor
-
-Checks for use of PHP 4 constructors and discourages it.
-
-#### OptionalParamBeforeRequired
-
-Checks if any optional parameters are before a required one. For example: `function ($a = 1, $b)`
-
-#### PropertyDefinitionDefaultValue
-
-Checks if any Property Definition is done with a default null value (not needed). For example: `$a = null`
-
-#### RandomApiMigration
-
-Checks for use of old rand, srand, getrandmax functions and suggests alternatives.
-
-#### RegularExpressions
-
-Checks that regular expressions are syntactically correct.
-
-#### ReturnAndYieldInOneMethod
-
-Checks for using return and yield statements in a one method and discourages it.
-
-#### StaticUsage
-
-Discourages the use of static variables (not properties).
-
-#### StupidUnaryOperators
+#### stupid_unary_operators
 
 Checks for use of UnaryPlus `+$a` and suggests to use an int or float cast instead.
 
-#### TestAnnotation
-
-Checks for use of `@test` when methods name begins with test, since it is unnecessary.
-
-#### UnexpectedUseOfThis
-
-Checks for behavior that would result in overwriting $this variable.
-
-#### UseCast
-
-Checks for use of functions like boolval, strval and others and suggests the use of casts.
-
-#### VariableVariableUsage
+#### variable_variable_usage
 
 Discourages the use of variable variables.
 
-#### YodaCondition
+#### casts
+
+Checks for casts that try to cast a type to itself.
+
+#### eval_usage
+
+Discourages the use of `eval()`.
+
+#### final_static_usage
+
+Checks for use of `static::` inside a final class.
+
+#### compare_with_array
+
+Checks for `{type array} > 1` and similar and suggests use of `count()`.
+
+#### division_from_zero
+
+Checks for division from 0. For example: `0/$x`, `false%$x`
+
+#### division_by_one
+
+Checks for division by 1. For example: `$x/1`, `$x%true`
+
+#### backtick_usage
+
+Discourages the use of backtick operator for shell execution.
+
+#### logic_inversion
+
+Checks for Logic inversion like `if (!($a == $b))` and suggests the correct operator.
+
+#### exit_usage
+
+Discourages the use of `exit()` and `die()`.
+
+#### array_short_definition
+
+Recommends the use of [] short syntax for arrays.
+
+#### array_duplicate_keys
+
+This inspection reports any duplicated keys on array creation expression.
+If multiple elements in the array declaration use the same key, only the last
+one will be used as all others are overwritten.
+
+#### array_illegal_offset_type
+
+Checks for illegal array key types (for example objects).
+
+#### alias_check
+
+Checks for use of alias functions and suggests the use of the originals.
+
+#### debug_code
+
+Checks for use of debug code and suggests to remove it.
+
+#### random_api_migration
+
+Checks for use of old rand, srand, getrandmax functions and suggests alternatives.
+
+#### use_cast
+
+Checks for use of functions like boolval, strval and others and suggests the use of casts.
+
+#### deprecated_ini_options
+
+Checks for use of deprecated php.ini options and gives alternatives if available.
+
+#### regular_expressions
+
+Checks that regular expressions are syntactically correct.
+
+#### argument_unpacking
+
+Checks for use of `func_get_args()` and suggests the use of argument unpacking. (... operator)
+
+#### deprecated_functions
+
+Checks for use of deprecated functions and gives alternatives if available.
+
+#### magic_method_parameters
+
+Checks that magic methods have the right amount of parameters.
+
+#### goto_usage
+
+Discourages the use of goto and goto labels.
+
+#### global_usage
+
+Discourages the use of `global $var;`.
+
+#### has_more_than_one_property
+
+Checks for multiple property definitions in one line. For example public $a, $b; and discourages it.
+
+#### missing_break_statement
+
+Checks for a missing break or return statement in switch cases. Can ignore empty cases and the last case.
+
+#### missing_visibility
+
+Checks for missing visibility modifiers for properties and methods.
+
+#### method_cannot_return
+
+Checks for return statements in `__construct` and `__destruct` since they can't return anything.
+
+#### unexpected_use_of_this
+
+Checks for behavior that would result in overwriting $this variable.
+
+#### test_annotation
+
+Checks for use of `@test` when methods name begins with test, since it is unnecessary.
+
+#### missing_docblock
+
+Checks for a missing docblock for: class, property, class constant, trait, interface, class method, function.
+
+#### old_constructor
+
+Checks for use of PHP 4 constructors and discourages it.
+
+#### constant_naming
+
+Checks that constants are all uppercase.
+
+#### missing_body
+
+Checks that statements that define a block of statements are not empty.
+
+#### inline_html_usage
+
+Discourages the use of inline html.
+
+#### assignment_in_condition
+
+Checks for assignments in conditions. (= instead of ==)
+
+#### static_usage
+
+Discourages the use of static variables (not properties).
+
+#### optional_param_before_required
+
+Checks if any optional parameters are before a required one. For example: `function ($a = 1, $b)`
+
+#### yoda_condition
 
 Checks for Yoda conditions, where a constant is placed before the variable. For example: `if (3 == $a)`
+
+#### for_condition
+
+Discourages the use of `for` with multiple conditions.
+
+#### property_definition_default_value
+
+Checks if any Property Definition is done with a default null value (not needed). For example: `$a = null`
+
+#### return_and_yield_in_one_method
+
+Checks for using return and yield statements in a one method and discourages it.
+
+#### check_l_number_kind
+
+Using octal, hexadecimal or binary integers is discouraged.
 
 Next: [How To: Write own Analyzer](./06_HowTo_Own_Analyzer.md)

--- a/src/Analyzer/Factory.php
+++ b/src/Analyzer/Factory.php
@@ -36,6 +36,28 @@ class Factory
     }
 
     /**
+     * @return \PHPSA\Analyzer\Pass\Metadata[]
+     */
+    public static function getPassesMetadata()
+    {
+        $meta = [];
+
+        foreach (self::getExpressionPasses() as $passClass) {
+            $meta[] = $passClass::getMetadata();
+        }
+
+        foreach (self::getStatementPasses() as $passClass) {
+            $meta[] = $passClass::getMetadata();
+        }
+
+        foreach (self::getScalarPasses() as $passClass) {
+            $meta[] = $passClass::getMetadata();
+        }
+
+        return $meta;
+    }
+
+    /**
      * @param EventManager $eventManager
      * @param Configuration $config
      * @return Analyzer

--- a/src/Application.php
+++ b/src/Application.php
@@ -33,6 +33,7 @@ class Application extends \Symfony\Component\Console\Application
 
         $this->add(new Command\CheckCommand());
         $this->add(new Command\DumpReferenceCommand());
+        $this->add(new Command\DumpDocumentationCommand());
 
         $this->issuesCollector = new IssuesCollector();
         $this->configuration = new Configuration();

--- a/src/Command/DumpDocumentationCommand.php
+++ b/src/Command/DumpDocumentationCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace PHPSA\Command;
+
+use PHPSA\Analyzer;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DumpDocumentationCommand extends Command
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('config:dump-documentation')
+            ->setDescription('Dumps the analyzer documentation')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $metaArray = Analyzer\Factory::getPassesMetadata();
+        
+        $output->writeln("# Analyzers");
+        $output->writeln("This doc gives an overview about what the different analyzers do.");
+        $output->writeln("");
+
+        foreach ($metaArray as $analyzer) {
+            $output->writeln("#### " . $analyzer->getName());
+            $output->writeln("");
+            $output->writeln($analyzer->getDescription());
+            $output->writeln("");
+        }
+
+        $output->writeln("Next: [How To: Write own Analyzer](./06_HowTo_Own_Analyzer.md)");
+    }
+}


### PR DESCRIPTION
Hey!

Type: new feature

Link to issue: #241 

This pull request affects the following components **(please check boxes):**

* [x] Core
* [x] Analyzer
* [ ] Compiler
* [ ] Control Flow Graph
* [x] Documentation

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/ovr/phpsa/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Made a simple command that creates the analyzer documentation. The names there are now in snake case ... but I think that's ok.
Also a new makefile thing which dumps config and docs in correct file.