### PR TITLE
Add UnsafeUnserialize analyzer

### DIFF
--- a/.phpsa.yml
+++ b/.phpsa.yml
@@ -100,6 +100,10 @@ phpsa:
         argument_unpacking:
             enabled:              true
 
+        # Checks for use of `unserialize()` without a 2nd parameter defining the allowed classes. Requires PHP 7.0+
+        unsafe_unserialize:
+            enabled:              true
+
         # Checks for use of deprecated functions and gives alternatives if available.
         deprecated_functions:
             enabled:              true

--- a/docs/05_Analyzers.md
+++ b/docs/05_Analyzers.md
@@ -95,6 +95,10 @@ Checks that regular expressions are syntactically correct.
 
 Checks for use of `func_get_args()` and suggests the use of argument unpacking. (... operator)
 
+#### unsafe_unserialize
+
+Checks for use of `unserialize()` without a 2nd parameter defining the allowed classes. Requires PHP 7.0+
+
 #### deprecated_functions
 
 Checks for use of deprecated functions and gives alternatives if available.

--- a/src/Analyzer/Factory.php
+++ b/src/Analyzer/Factory.php
@@ -168,6 +168,7 @@ class Factory
             AnalyzerPass\Expression\FunctionCall\DeprecatedIniOptions::class,
             AnalyzerPass\Expression\FunctionCall\RegularExpressions::class,
             AnalyzerPass\Expression\FunctionCall\ArgumentUnpacking::class,
+            AnalyzerPass\Expression\FunctionCall\UnsafeUnserialize::class,
             AnalyzerPass\Expression\FunctionCall\DeprecatedFunctions::class,
         ];
     }

--- a/src/Analyzer/Pass/Expression/FunctionCall/UnsafeUnserialize.php
+++ b/src/Analyzer/Pass/Expression/FunctionCall/UnsafeUnserialize.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace PHPSA\Analyzer\Pass\Expression\FunctionCall;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPSA\Context;
+
+class UnsafeUnserialize extends AbstractFunctionCallAnalyzer
+{
+    const DESCRIPTION = 'Checks for use of `unserialize()` without a 2nd parameter defining the allowed classes. Requires PHP 7.0+';
+
+    public function pass(FuncCall $funcCall, Context $context)
+    {
+        $functionName = $this->resolveFunctionName($funcCall, $context);
+
+        if ($functionName !== 'unserialize') {
+            return false;
+        }
+
+        if (count($funcCall->args) < 2) {
+            $context->notice(
+                'unsafe.unserialize',
+                sprintf('unserialize() should be used with a list of allowed classes or false as 2nd parameter.'),
+                $funcCall
+            );
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getMetadata()
+    {
+        $metaData = parent::getMetadata();
+        $metaData->setRequiredPhpVersion('7.0');
+
+        return $metaData;
+    }
+}

--- a/tests/analyze-fixtures/Expression/FunctionCall/UnsafeUnserialize.php
+++ b/tests/analyze-fixtures/Expression/FunctionCall/UnsafeUnserialize.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Analyze\Fixtures\Expression\FunctionCall;
+
+class UnsafeUnserialize
+{
+    public function testWithoutParam()
+    {
+        return unserialize("i:1;");
+    }
+
+    public function testWithParam()
+    {
+        return unserialize("i:1;", false);
+    }
+}
+
+?>
+----------------------------
+PHPSA\Analyzer\Pass\Expression\FunctionCall\UnsafeUnserialize
+----------------------------
+[
+    {
+        "type":"unsafe.unserialize",
+        "message":"unserialize() should be used with a list of allowed classes or false as 2nd parameter.",
+        "file":"UnsafeUnserialize.php",
+        "line":8
+    }
+]


### PR DESCRIPTION
Hey!

Type: new feature

Link to issue:

This pull request affects the following components **(please check boxes):**

* [ ] Core
* [x] Analyzer
* [ ] Compiler
* [ ] Control Flow Graph
* [ ] Documentation

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/ovr/phpsa/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Added analyzer for PHP7.0+ that checks for use of the 2nd parameter for unserialize() to define the allowed classes (or false for none).
