### PR TITLE
Make compiler notices configurable

### DIFF
--- a/.phpsa.yml
+++ b/.phpsa.yml
@@ -6,6 +6,10 @@ phpsa:
     parser:               prefer-7 # One of "prefer-7"; "prefer-5"; "only-7"; "only-5"
     analyzers:
 
+        # Contains all compiler notices. Those are raised when PHP with strict error reporting would create at least a Notice message. (mostly experimental)
+        language_error:
+            enabled:              true
+
         # Discourages the use of the `@` operator to silence errors.
         error_suppression:
             enabled:              true

--- a/src/Compiler/Expression.php
+++ b/src/Compiler/Expression.php
@@ -428,7 +428,7 @@ class Expression
                 }
             } else {
                 $this->context->notice(
-                    'no-parent',
+                    'language_error',
                     'Cannot access parent:: when current class scope has no parent',
                     $expr
                 );

--- a/src/Compiler/Expression/ArrayDimFetch.php
+++ b/src/Compiler/Expression/ArrayDimFetch.php
@@ -27,7 +27,7 @@ class ArrayDimFetch extends AbstractExpressionCompiler
 
         if (!$var->isArray()) {
             $context->notice(
-                'array_dim_fetch_on_non_array',
+                'language_error',
                 "It's not possible to fetch an array element on a non array",
                 $expr
             );
@@ -37,7 +37,7 @@ class ArrayDimFetch extends AbstractExpressionCompiler
 
         if (!in_array($dim->getValue(), $var->getValue())) {
             $context->notice(
-                'array_dim_fetch_not_found',
+                'language_error',
                 "The array does not contain this value",
                 $expr
             );

--- a/src/Compiler/Expression/AssignOp/Div.php
+++ b/src/Compiler/Expression/AssignOp/Div.php
@@ -25,7 +25,7 @@ class Div extends AbstractExpressionCompiler
 
         if ($expExpression->isEquals(0)) {
             $context->notice(
-                'language-error',
+                'language_error',
                 'You are trying to divide by 0.',
                 $expr
             );

--- a/src/Compiler/Expression/AssignOp/Mod.php
+++ b/src/Compiler/Expression/AssignOp/Mod.php
@@ -30,7 +30,7 @@ class Mod extends AbstractExpressionCompiler
 
         if ($expExpression->isEquals(0)) {
             $context->notice(
-                'language-error',
+                'language_error',
                 'You are trying to divide by 0.',
                 $expr
             );

--- a/src/Compiler/Expression/ClassConstFetch.php
+++ b/src/Compiler/Expression/ClassConstFetch.php
@@ -33,7 +33,7 @@ class ClassConstFetch extends AbstractExpressionCompiler
             if ($leftCEValue instanceof ClassDefinition) {
                 if (!$leftCEValue->hasConst($expr->name, true)) {
                     $context->notice(
-                        'undefined-const',
+                        'language_error',
                         sprintf('Constant %s does not exist in %s scope', $expr->name, $expr->class),
                         $expr
                     );

--- a/src/Compiler/Expression/FunctionCall.php
+++ b/src/Compiler/Expression/FunctionCall.php
@@ -66,7 +66,7 @@ class FunctionCall extends AbstractExpressionCompiler
 
         if (!$exists) {
             $context->notice(
-                'undefined-fcall',
+                'language_error',
                 sprintf('Function %s() does not exist', $expr->name->parts[0]),
                 $expr
             );

--- a/src/Compiler/Expression/MethodCall.php
+++ b/src/Compiler/Expression/MethodCall.php
@@ -35,7 +35,7 @@ class MethodCall extends AbstractExpressionCompiler
                 if ($methodName) {
                     if (!$calledObject->hasMethod($methodName, true)) {
                         $context->notice(
-                            'mcall.undefined',
+                            'language_error',
                             sprintf('Method %s() does not exist in %s scope', $methodName, $calledObject->getName()),
                             $expr
                         );
@@ -52,7 +52,7 @@ class MethodCall extends AbstractExpressionCompiler
 
                     if ($method->isStatic()) {
                         $context->notice(
-                            'mcall.static',
+                            'language_error',
                             "Method {$methodName}() is static but called like a class method",
                             $expr
                         );
@@ -64,7 +64,7 @@ class MethodCall extends AbstractExpressionCompiler
             return new CompiledExpression();
         } else {
             $context->notice(
-                'mcall.non-object',
+                'language_error',
                 sprintf('$%s is not an object and cannot be called like this', $expr->var->name),
                 $expr->var,
                 Check::CHECK_ALPHA

--- a/src/Compiler/Expression/Operators/Arithmetical/Div.php
+++ b/src/Compiler/Expression/Operators/Arithmetical/Div.php
@@ -30,7 +30,7 @@ class Div extends AbstractExpressionCompiler
 
         if ($right->isEquals(0)) {
             $context->notice(
-                'language-error',
+                'language_error',
                 'You are trying to divide by 0.',
                 $expr
             );

--- a/src/Compiler/Expression/Operators/Arithmetical/Mod.php
+++ b/src/Compiler/Expression/Operators/Arithmetical/Mod.php
@@ -30,7 +30,7 @@ class Mod extends AbstractExpressionCompiler
 
         if ($right->isEquals(0)) {
             $context->notice(
-                'language-error',
+                'language_error',
                 'You are trying to divide by 0.',
                 $expr
             );

--- a/src/Compiler/Expression/Operators/PostDec.php
+++ b/src/Compiler/Expression/Operators/PostDec.php
@@ -45,14 +45,14 @@ class PostDec extends AbstractExpressionCompiler
                 }
 
                 $context->notice(
-                    'postdec.variable.wrong-type',
+                    'language_error',
                     'You are trying to use post decrement operator on variable $' . $variableName .
                     ' with type: ' . $variable->getTypeName(),
                     $expr
                 );
             } else {
                 $context->notice(
-                    'postdec.undefined-variable',
+                    'language_error',
                     'You are trying to use post decrement operator on undefined variable: ' . $variableName,
                     $expr
                 );

--- a/src/Compiler/Expression/Operators/PostInc.php
+++ b/src/Compiler/Expression/Operators/PostInc.php
@@ -45,14 +45,14 @@ class PostInc extends AbstractExpressionCompiler
                 }
 
                 $context->notice(
-                    'postinc.variable.wrong-type',
+                    'language_error',
                     'You are trying to use post increment operator on variable $' . $variableName .
                     ' with type: ' . $variable->getTypeName(),
                     $expr
                 );
             } else {
                 $context->notice(
-                    'postinc.undefined-variable',
+                    'language_error',
                     'You are trying to use post increment operator on undefined variable: ' . $variableName,
                     $expr
                 );

--- a/src/Compiler/Expression/Operators/PreDec.php
+++ b/src/Compiler/Expression/Operators/PreDec.php
@@ -40,14 +40,14 @@ class PreDec extends AbstractExpressionCompiler
                 }
 
                 $context->notice(
-                    'predec.variable.wrong-type',
+                    'language_error',
                     'You are trying to use pre decrement operator on variable $' . $variableName .
                     ' with type: ' . $variable->getTypeName(),
                     $expr
                 );
             } else {
                 $context->notice(
-                    'predec.undefined-variable',
+                    'language_error',
                     'You are trying to use pre decrement operator on undefined variable: ' . $variableName,
                     $expr
                 );

--- a/src/Compiler/Expression/Operators/PreInc.php
+++ b/src/Compiler/Expression/Operators/PreInc.php
@@ -40,14 +40,14 @@ class PreInc extends AbstractExpressionCompiler
                 }
 
                 $context->notice(
-                    'preinc.variable.wrong-type',
+                    'language_error',
                     'You are trying to use pre increment operator on variable $' . $variableName .
                     ' with type: ' . $variable->getTypeName(),
                     $expr
                 );
             } else {
                 $context->notice(
-                    'preinc.undefined-variable',
+                    'language_error',
                     'You are trying to use pre increment operator on undefined variable: ' . $variableName,
                     $expr
                 );

--- a/src/Compiler/Expression/PropertyFetch.php
+++ b/src/Compiler/Expression/PropertyFetch.php
@@ -35,7 +35,7 @@ class PropertyFetch extends AbstractExpressionCompiler
                         return $compiler->compile($property);
                     } else {
                         $context->notice(
-                            'undefined-property',
+                            'language_error',
                             sprintf(
                                 'Property %s does not exist in %s scope',
                                 $propertyName,
@@ -53,7 +53,7 @@ class PropertyFetch extends AbstractExpressionCompiler
         }
 
         $context->notice(
-            'property-fetch-on-non-object',
+            'language_error',
             "It's not possible to fetch a property on a non-object",
             $expr,
             Check::CHECK_BETA

--- a/src/Compiler/Expression/StaticCall.php
+++ b/src/Compiler/Expression/StaticCall.php
@@ -34,7 +34,7 @@ class StaticCall extends AbstractExpressionCompiler
             $classDefinition = $context->scope;
             if (!$classDefinition->hasMethod($name, true)) {
                 $context->notice(
-                    'undefined-scall',
+                    'language_error',
                     sprintf('Static method %s() does not exist in %s scope', $name, $expr->class),
                     $expr
                 );
@@ -45,7 +45,7 @@ class StaticCall extends AbstractExpressionCompiler
             $method = $classDefinition->getMethod($name, true);
             if ($expr->class->parts[0] !== 'parent' && !$method->isStatic()) {
                 $context->notice(
-                    'undefined-scall',
+                    'language_error',
                     sprintf('Method %s() is not static but was called in a static way', $name),
                     $expr
                 );

--- a/src/Compiler/Expression/StaticPropertyFetch.php
+++ b/src/Compiler/Expression/StaticPropertyFetch.php
@@ -34,7 +34,7 @@ class StaticPropertyFetch extends AbstractExpressionCompiler
             $classDefinition = $context->scope;
             if (!$classDefinition->hasProperty($name, true)) {
                 $context->notice(
-                    'undefined-scall',
+                    'language_error',
                     sprintf('Static property $%s does not exist in %s scope', $name, $expr->class),
                     $expr
                 );
@@ -45,7 +45,7 @@ class StaticPropertyFetch extends AbstractExpressionCompiler
             $property = $classDefinition->getPropertyStatement($name, true);
             if (!$property->isStatic()) {
                 $context->notice(
-                    'undefined-scall',
+                    'language_error',
                     sprintf('Property $%s is not static but was called in a static way', $name),
                     $expr
                 );

--- a/src/Compiler/Statement/BreakSt.php
+++ b/src/Compiler/Statement/BreakSt.php
@@ -24,7 +24,7 @@ class BreakSt extends AbstractCompiler
             
             if (!($stmt->num instanceof LNumber) || $compiled->getValue() == 0) {
                 $context->notice(
-                    'language-error',
+                    'language_error',
                     'Break only supports positive integers.',
                     $stmt
                 );

--- a/src/Compiler/Statement/ContinueSt.php
+++ b/src/Compiler/Statement/ContinueSt.php
@@ -24,7 +24,7 @@ class ContinueSt extends AbstractCompiler
 
             if (!($stmt->num instanceof LNumber) || $compiled->getValue() == 0) {
                 $context->notice(
-                    'language-error',
+                    'language_error',
                     'Continue only supports positive integers.',
                     $stmt
                 );

--- a/src/Compiler/Statement/ReturnSt.php
+++ b/src/Compiler/Statement/ReturnSt.php
@@ -25,7 +25,7 @@ class ReturnSt extends AbstractCompiler
         switch ($compiledExpression->getType()) {
             case CompiledExpression::VOID:
                 $context->notice(
-                    'return.void',
+                    'language_error',
                     'You are trying to return void',
                     $stmt
                 );

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -76,6 +76,12 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('analyzers')
                 ->addDefaultsIfNotSet();
 
+        $language_error = (new TreeBuilder())->root('language_error')
+            ->info("Contains all compiler notices. Those are raised when PHP with strict error reporting would create at least a Notice message. (mostly experimental)")
+            ->canBeDisabled();
+
+        $analyzersConfigRoot->append($language_error);
+
         foreach ($analyzersConfiguration as $config) {
             $analyzersConfigRoot->append($config);
         }

--- a/src/Context.php
+++ b/src/Context.php
@@ -193,6 +193,12 @@ class Context
      */
     public function notice($type, $message, \PhpParser\NodeAbstract $expr, $status = Check::CHECK_SAFE)
     {
+        $analyzerConfig = $this->application->getConfiguration()->getValue('analyzers');
+
+        if ($type == "language_error" && !$analyzerConfig['language_error']['enabled']) {
+            return true;
+        }
+
         $filepath = $this->filepath;
         $code = file($filepath);
 


### PR DESCRIPTION
Hey!

Type: new feature

Link to issue: #276 

This pull request affects the following components **(please check boxes):**

* [x] Core
* [ ] Analyzer
* [x] Compiler
* [ ] Control Flow Graph
* [ ] Documentation

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/ovr/phpsa/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Renames every compiler notice to type language_error and makes them configurable. If disabled only syntax-errors and enabled analyzers will notice. If all analyzers are disabled too only syntax errors will be shown.
With this we can finally disable all those false notices we currently get :+1: 
