### PR TITLE
Update PHPParser to version 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Notice:  Missing docblock for callStaticMethodBySelf() method in fixtures/Compil
 
 ### Requirements
 
-PHP >= 5.5 (compatible up to version 7.0 && hhvm), but you can check files for PHP >= 5.2 with this.
+PHP >= 5.6 (compatible up to version 7.1 && hhvm), but you can check files for PHP >= 5.2 with this.
 
 ### Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
+        "php": ">=5.6",
         "ovr/phpreflection": "^0.3.1",
         "symfony/console": "^3.0.5",
         "symfony/event-dispatcher": "^3.0.5",
         "symfony/config": "^3.0.5",
         "symfony/yaml": "^3.0.5",
-        "nikic/php-parser": "^2.1",
+        "nikic/php-parser": "^3.0",
         "phpdocumentor/reflection-docblock": "^3.0",
         "phpdocumentor/type-resolver": "^0.2",
         "webiny/event-manager": "^1.4.1",

--- a/docs/04_Components.md
+++ b/docs/04_Components.md
@@ -8,7 +8,7 @@ The Core component contains all the things that are used by multiple other compo
 
 ### Compiler
 
-The Compiler can compile your PHP Code version 5.2 to 7.0 and can notice every syntax error (and in the future language level errors).
+The Compiler can compile your PHP Code version 5.2 to 7.1 and can notice every syntax error and some language level errors (those can be turned off via configuration).
 
 ### Analyzer
 

--- a/src/Analyzer/Pass/Expression/VariableVariableUsage.php
+++ b/src/Analyzer/Pass/Expression/VariableVariableUsage.php
@@ -62,13 +62,13 @@ class VariableVariableUsage implements Pass\AnalyzerPassInterface
     {
         $result = false;
 
-        foreach ($expr->vars as $var) {
+        foreach ($expr->items as $var) {
             // list($a, ) = …
-            if (!$var) {
+            if ($var === null) {
                 continue;
             }
 
-            $result = $this->analyzeVar($var, $context) || $result;
+            $result = $this->analyzeVar($var->value, $context) || $result;
         }
 
         return $result;

--- a/src/Compiler/Expression/ArrayOp.php
+++ b/src/Compiler/Expression/ArrayOp.php
@@ -29,6 +29,10 @@ class ArrayOp extends AbstractExpressionCompiler
         $resultArray = [];
 
         foreach ($expr->items as $item) {
+            if ($item === null) {
+                continue;
+            }
+
             $compiledValueResult = $compiler->compile($item->value);
             if ($item->key) {
                 $compiledKeyResult = $compiler->compile($item->key);

--- a/src/Compiler/Expression/Assign.php
+++ b/src/Compiler/Expression/Assign.php
@@ -28,20 +28,23 @@ class Assign extends AbstractExpressionCompiler
         if ($expr->var instanceof Node\Expr\List_) {
             $isCorrectType = $compiledExpression->isArray();
 
-            foreach ($expr->var->vars as $key => $var) {
-                if (!$var instanceof Node\Expr\Variable) {
+            foreach ($expr->var->items as $var) {
+                if ($var === null) {
+                    continue;
+                }
+                if (!$var->value instanceof Node\Expr\Variable) {
                     continue;
                 }
 
-                if ($var->name instanceof Node\Expr\Variable) {
-                    $this->compileVariableDeclaration($compiler->compile($var->name), new CompiledExpression(), $context);
+                if ($var->value->name instanceof Node\Expr\Variable) {
+                    $this->compileVariableDeclaration($compiler->compile($var->value->name), new CompiledExpression(), $context);
                     continue;
                 }
 
-                $symbol = $context->getSymbol($var->name);
+                $symbol = $context->getSymbol($var->value->name);
                 if (!$symbol) {
                     $symbol = new \PHPSA\Variable(
-                        $var->name,
+                        $var->value->name,
                         null,
                         CompiledExpression::UNKNOWN,
                         $context->getCurrentBranch()

--- a/src/Compiler/Statement.php
+++ b/src/Compiler/Statement.php
@@ -51,6 +51,8 @@ class Statement
                 return new Statement\TryCatchSt();
             case Stmt\Catch_::class:
                 return new Statement\CatchSt();
+            case Stmt\Finally_::class:
+                return new Statement\FinallySt();
             case Stmt\Throw_::class:
                 return new Statement\ThrowSt();
             case Stmt\Global_::class:

--- a/src/Compiler/Statement/FinallySt.php
+++ b/src/Compiler/Statement/FinallySt.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace PHPSA\Compiler\Statement;
+
+use PHPSA\Context;
+
+class FinallySt extends AbstractCompiler
+{
+    protected $name = '\PhpParser\Node\Stmt\Finally_';
+
+    /**
+     * @param \PhpParser\Node\Stmt\Finally_ $statement
+     * @param Context $context
+     */
+    public function compile($statement, Context $context)
+    {
+        foreach ($statement->stmts as $stmt) {
+            \PHPSA\nodeVisitorFactory($stmt, $context);
+        }
+    }
+}

--- a/src/Compiler/Statement/TryCatchSt.php
+++ b/src/Compiler/Statement/TryCatchSt.php
@@ -27,12 +27,8 @@ class TryCatchSt extends AbstractCompiler
             \PHPSA\nodeVisitorFactory($stmt, $context);
         }
 
-        if ($statement->finallyStmts !== null) {
-            if (count($statement->finallyStmts) > 0) {
-                foreach ($statement->finallyStmts as $stmt) {
-                    \PHPSA\nodeVisitorFactory($stmt, $context);
-                }
-            }
+        if ($statement->finally !== null) {
+            \PHPSA\nodeVisitorFactory($statement->finally, $context);
         }
     }
 }

--- a/src/Definition/ClassDefinition.php
+++ b/src/Definition/ClassDefinition.php
@@ -47,7 +47,7 @@ class ClassDefinition extends ParentDefinition
     /**
      * Class constants
      *
-     * @var Node\Stmt\Const_[]
+     * @var string[]
      */
     protected $constants = [];
 

--- a/src/Definition/FileParser.php
+++ b/src/Definition/FileParser.php
@@ -127,7 +127,7 @@ class FileParser
 
                 $this->compiler->addTrait($definition);
             } elseif ($statement instanceof Node\Stmt\Class_) {
-                $definition = new ClassDefinition($statement->name, $statement, $statement->type);
+                $definition = new ClassDefinition($statement->name, $statement, $statement->flags);
                 $definition->setFilepath($filepath);
                 $definition->setNamespace($aliasManager->getNamespace());
 
@@ -144,7 +144,7 @@ class FileParser
                 foreach ($statement->stmts as $stmt) {
                     if ($stmt instanceof Node\Stmt\ClassMethod) {
                         $definition->addMethod(
-                            new ClassMethod($stmt->name, $stmt, $stmt->type)
+                            new ClassMethod($stmt->name, $stmt, $stmt->flags)
                         );
                     } elseif ($stmt instanceof Node\Stmt\Property) {
                         $definition->addProperty($stmt);


### PR DESCRIPTION
Hey!

Type: new feature | documentation

Link to issue: #96 

This pull request affects the following components **(please check boxes):**

* [x] Core
* [x] Analyzer
* [x] Compiler
* [ ] Control Flow Graph
* [x] Documentation

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/ovr/phpsa/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

- Changed PHPParser to version 3
- bumped phpsa min version to php 5.6 (up from php 5.5) but it can still check php 5.2 to 7.1

This only fixes BC's. New PHP 7.1 Features (new types, NullableType Node) are not yet added.