### PR TITLE
Use array short definition for data providers

### DIFF
--- a/tests/PHPSA/Compiler/Expression/AssignOp/BitwiseAndTest.php
+++ b/tests/PHPSA/Compiler/Expression/AssignOp/BitwiseAndTest.php
@@ -13,18 +13,18 @@ class BitwiseAndTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProviderInteger()
     {
-        return array(
-            array(0, 5, 0),
-            array(1, 5, 1),
-            array(4, 5, 4),
-            array(-1, 5, 5),
-            array(1.4, 5, 1),
-            array(-19.7, 1, 1),
-            array(true, true, 1),
-            array(false, true, 0),
-            array(true, false, 0),
-            array(false, false, 0),
-        );
+        return [
+            [0, 5, 0],
+            [1, 5, 1],
+            [4, 5, 4],
+            [-1, 5, 5],
+            [1.4, 5, 1],
+            [-19.7, 1, 1],
+            [true, true, 1],
+            [false, true, 0],
+            [true, false, 0],
+            [false, false, 0],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/AssignOp/BitwiseOrTest.php
+++ b/tests/PHPSA/Compiler/Expression/AssignOp/BitwiseOrTest.php
@@ -13,18 +13,18 @@ class BitwiseOrTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProvider()
     {
-        return array(
-            array(0, 5, 5),
-            array(1, 5, 5),
-            array(4, 5, 5),
-            array(-1, 5, -1),
-            array(1.4, 5, 5),
-            array(-19.7, 1, -19),
-            array(true, true, 1),
-            array(false, true, 1),
-            array(true, false, 1),
-            array(false, false, 0),
-        );
+        return [
+            [0, 5, 5],
+            [1, 5, 5],
+            [4, 5, 5],
+            [-1, 5, -1],
+            [1.4, 5, 5],
+            [-19.7, 1, -19],
+            [true, true, 1],
+            [false, true, 1],
+            [true, false, 1],
+            [false, false, 0],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/AssignOp/BitwiseXorTest.php
+++ b/tests/PHPSA/Compiler/Expression/AssignOp/BitwiseXorTest.php
@@ -13,18 +13,18 @@ class BitwiseXorTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProvider()
     {
-        return array(
-            array(0, 5, 5),
-            array(1, 5, 4),
-            array(4, 5, 1),
-            array(-1, 5, -6),
-            array(1.4, 5, 4),
-            array(-19.7, 1, -20),
-            array(true, true, 0),
-            array(false, true, 1),
-            array(true, false, 1),
-            array(false, false, 0),
-        );
+        return [
+            [0, 5, 5],
+            [1, 5, 4],
+            [4, 5, 1],
+            [-1, 5, -6],
+            [1.4, 5, 4],
+            [-19.7, 1, -20],
+            [true, true, 0],
+            [false, true, 1],
+            [true, false, 1],
+            [false, false, 0],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/AssignOp/ConcatTest.php
+++ b/tests/PHPSA/Compiler/Expression/AssignOp/ConcatTest.php
@@ -15,20 +15,20 @@ class ConcatTest extends \Tests\PHPSA\TestCase
      */
     public function concatDataProvider()
     {
-        return array(
-            array(2, 2, "22"),
-            array(true, "a", "1a"),
-            array("a", true, "a1"),
-            array(true, true, "11"),
-            array(-1, 1, "-11"),
-            array(false, 3, "3"), // 0 at beginning is dropped
-            array(false, true, "1"),
-            array(0, -1, "0-1"),
-            array(1.5, -1, "1.5-1"),
-            array(true, -0.5, "1-0.5"),
-            array(false, false, ""),
-            array(true, false, "1"),
-        );
+        return [
+            [2, 2, "22"],
+            [true, "a", "1a"],
+            ["a", true, "a1"],
+            [true, true, "11"],
+            [-1, 1, "-11"],
+            [false, 3, "3"], // 0 at beginning is dropped
+            [false, true, "1"],
+            [0, -1, "0-1"],
+            [1.5, -1, "1.5-1"],
+            [true, -0.5, "1-0.5"],
+            [false, false, ""],
+            [true, false, "1"],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/AssignOp/DivTest.php
+++ b/tests/PHPSA/Compiler/Expression/AssignOp/DivTest.php
@@ -15,18 +15,18 @@ class DivTest extends \Tests\PHPSA\TestCase
      */
     public function divResultIntDataProvider()
     {
-        return array(
-            array(2, 2, 1),
-            array(true, 1, 1),
-            array(3, true, 3),
-            array(true, true, 1),
-            array(2, 1, 2),
-            array(-1, 1, -1),
-            array(false, -3, 0),
-            array(false, 1, 0),
-            array(0, 1, 0),
-            array(false, true, 0),
-        );
+        return [
+            [2, 2, 1],
+            [true, 1, 1],
+            [3, true, 3],
+            [true, true, 1],
+            [2, 1, 2],
+            [-1, 1, -1],
+            [false, -3, 0],
+            [false, 1, 0],
+            [0, 1, 0],
+            [false, true, 0],
+        ];
     }
 
     /**
@@ -55,14 +55,14 @@ class DivTest extends \Tests\PHPSA\TestCase
      */
     public function divResultDoubleDataProvider()
     {
-        return array(
-            array(2, 0.5, 4.0),
-            array(1.5, 0.5, 3.0),
-            array(true, 2, 0.5),
-            array(false, -5.5, 0.0),
-            array(1.5, true, 1.5),
-            array(-1.5, 1, -1.5),
-        );
+        return [
+            [2, 0.5, 4.0],
+            [1.5, 0.5, 3.0],
+            [true, 2, 0.5],
+            [false, -5.5, 0.0],
+            [1.5, true, 1.5],
+            [-1.5, 1, -1.5],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/AssignOp/MinusTest.php
+++ b/tests/PHPSA/Compiler/Expression/AssignOp/MinusTest.php
@@ -15,19 +15,19 @@ class MinusTest extends \Tests\PHPSA\TestCase
      */
     public function minusResultIntDataProvider()
     {
-        return array(
-            array(2, 2, 0),
-            array(true, 2, -1),
-            array(3, true, 2),
-            array(true, true, 0),
-            array(2, 0, 2),
-            array(-1, 1, -2),
-            array(false, 3, -3),
-            array(2, false, 2),
-            array(false, false, 0),
-            array(0, 0, 0),
-            array(true, false, 1),
-        );
+        return [
+            [2, 2, 0],
+            [true, 2, -1],
+            [3, true, 2],
+            [true, true, 0],
+            [2, 0, 2],
+            [-1, 1, -2],
+            [false, 3, -3],
+            [2, false, 2],
+            [false, false, 0],
+            [0, 0, 0],
+            [true, false, 1],
+        ];
     }
 
     /**
@@ -56,15 +56,15 @@ class MinusTest extends \Tests\PHPSA\TestCase
      */
     public function minusResultDoubleDataProvider()
     {
-        return array(
-            array(2, 1.5, 0.5),
-            array(1.5, 2, -0.5),
-            array(true, 1.5, -0.5),
-            array(false, 1.5, -1.5),
-            array(1.5, false, 1.5),
-            array(1.5, true, 0.5),
-            array(-1.5, 1, -2.5),
-        );
+        return [
+            [2, 1.5, 0.5],
+            [1.5, 2, -0.5],
+            [true, 1.5, -0.5],
+            [false, 1.5, -1.5],
+            [1.5, false, 1.5],
+            [1.5, true, 0.5],
+            [-1.5, 1, -2.5],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/AssignOp/ModTest.php
+++ b/tests/PHPSA/Compiler/Expression/AssignOp/ModTest.php
@@ -15,17 +15,17 @@ class ModTest extends \Tests\PHPSA\TestCase
      */
     public function modDataProvider()
     {
-        return array(
-            array(2, 2, 0),
-            array(true, 2, 1),
-            array(3, true, 0),
-            array(true, true, 0),
-            array(-1, 1, 0),
-            array(false, 3, 0),
-            array(false, true, 0),
-            array(0, 1, 0),
-            array(1, -1, 0),
-        );
+        return [
+            [2, 2, 0],
+            [true, 2, 1],
+            [3, true, 0],
+            [true, true, 0],
+            [-1, 1, 0],
+            [false, 3, 0],
+            [false, true, 0],
+            [0, 1, 0],
+            [1, -1, 0],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/AssignOp/MulTest.php
+++ b/tests/PHPSA/Compiler/Expression/AssignOp/MulTest.php
@@ -15,19 +15,19 @@ class MulTest extends \Tests\PHPSA\TestCase
      */
     public function mulResultIntDataProvider()
     {
-        return array(
-            array(2, 2, 4),
-            array(true, 2, 2),
-            array(3, true, 3),
-            array(true, true, 1),
-            array(2, 0, 0),
-            array(false, 3, 0),
-            array(2, false, 0),
-            array(false, false, 0),
-            array(0, 0, 0),
-            array(true, false, 0),
-            array(-1, 2, -2),
-        );
+        return [
+            [2, 2, 4],
+            [true, 2, 2],
+            [3, true, 3],
+            [true, true, 1],
+            [2, 0, 0],
+            [false, 3, 0],
+            [2, false, 0],
+            [false, false, 0],
+            [0, 0, 0],
+            [true, false, 0],
+            [-1, 2, -2],
+        ];
     }
 
     /**
@@ -56,15 +56,15 @@ class MulTest extends \Tests\PHPSA\TestCase
      */
     public function mulResultDoubleDataProvider()
     {
-        return array(
-            array(2, 1.5, 3.0),
-            array(1.5, 1.5, 2.25),
-            array(true, 1.5, 1.5),
-            array(false, 1.5, 0.0),
-            array(1.5, false, 0.0),
-            array(1.5, true, 1.5),
-            array(-1.5, true, -1.5),
-        );
+        return [
+            [2, 1.5, 3.0],
+            [1.5, 1.5, 2.25],
+            [true, 1.5, 1.5],
+            [false, 1.5, 0.0],
+            [1.5, false, 0.0],
+            [1.5, true, 1.5],
+            [-1.5, true, -1.5],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/AssignOp/PlusTest.php
+++ b/tests/PHPSA/Compiler/Expression/AssignOp/PlusTest.php
@@ -15,18 +15,18 @@ class PlusTest extends \Tests\PHPSA\TestCase
      */
     public function plusResultIntDataProvider()
     {
-        return array(
-            array(2, 2, 4),
-            array(true, 2, 3),
-            array(3, true, 4),
-            array(true, true, 2),
-            array(2, 0, 2),
-            array(false, -1, -1),
-            array(2, false, 2),
-            array(false, false, 0),
-            array(-2, 1, -1),
-            array(true, false, 1),
-        );
+        return [
+            [2, 2, 4],
+            [true, 2, 3],
+            [3, true, 4],
+            [true, true, 2],
+            [2, 0, 2],
+            [false, -1, -1],
+            [2, false, 2],
+            [false, false, 0],
+            [-2, 1, -1],
+            [true, false, 1],
+        ];
     }
 
     /**
@@ -55,13 +55,13 @@ class PlusTest extends \Tests\PHPSA\TestCase
      */
     public function plusResultDoubleDataProvider()
     {
-        return array(
-            array(2, -1.5, 0.5),
-            array(1.5, 2, 3.5),
-            array(true, 1.5, 2.5),
-            array(1.5, false, 1.5),
-            array(true, -2.5, -1.5),
-        );
+        return [
+            [2, -1.5, 0.5],
+            [1.5, 2, 3.5],
+            [true, 1.5, 2.5],
+            [1.5, false, 1.5],
+            [true, -2.5, -1.5],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/AssignOp/PowTest.php
+++ b/tests/PHPSA/Compiler/Expression/AssignOp/PowTest.php
@@ -15,19 +15,19 @@ class PowTest extends \Tests\PHPSA\TestCase
      */
     public function powResultIntDataProvider()
     {
-        return array(
-            array(2, 2, 4),
-            array(true, 2, 1),
-            array(3, true, 3),
-            array(true, true, 1),
-            array(2, 0, 1),
-            array(false, 3, 0),
-            array(2, false, 1),
-            array(false, false, 1),
-            array(0, 0, 1),
-            array(0, 3, 0),
-            array(true, false, 1),
-        );
+        return [
+            [2, 2, 4],
+            [true, 2, 1],
+            [3, true, 3],
+            [true, true, 1],
+            [2, 0, 1],
+            [false, 3, 0],
+            [2, false, 1],
+            [false, false, 1],
+            [0, 0, 1],
+            [0, 3, 0],
+            [true, false, 1],
+        ];
     }
 
     /**
@@ -56,16 +56,16 @@ class PowTest extends \Tests\PHPSA\TestCase
      */
     public function powResultDoubleDataProvider()
     {
-        return array(
-            array(2, -2, 0.25),
-            array(1.5, 2, 2.25),
-            array(1, 1.5, 1.0),
-            array(100, 2.5, 100000.0),
-            array(true, 1.5, 1.0),
-            array(false, 1.5, 0.0),
-            array(1.5, false, 1.0),
-            array(1.5, true, 1.5),
-        );
+        return [
+            [2, -2, 0.25],
+            [1.5, 2, 2.25],
+            [1, 1.5, 1.0],
+            [100, 2.5, 100000.0],
+            [true, 1.5, 1.0],
+            [false, 1.5, 0.0],
+            [1.5, false, 1.0],
+            [1.5, true, 1.5],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/AssignOp/ShiftLeftTest.php
+++ b/tests/PHPSA/Compiler/Expression/AssignOp/ShiftLeftTest.php
@@ -13,18 +13,18 @@ class ShiftLeftTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProvider()
     {
-        return array(
-            array(0, 5, 0),
-            array(1, 5, 32),
-            array(4, 5, 128),
-            array(-1, 5, -32),
-            array(1.4, 5, 32),
-            array(-19.7, 2, -76),
-            array(true, true, 2),
-            array(false, true, 0),
-            array(true, false, 1),
-            array(false, false, 0),
-        );
+        return [
+            [0, 5, 0],
+            [1, 5, 32],
+            [4, 5, 128],
+            [-1, 5, -32],
+            [1.4, 5, 32],
+            [-19.7, 2, -76],
+            [true, true, 2],
+            [false, true, 0],
+            [true, false, 1],
+            [false, false, 0],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/AssignOp/ShiftRightTest.php
+++ b/tests/PHPSA/Compiler/Expression/AssignOp/ShiftRightTest.php
@@ -13,18 +13,18 @@ class ShiftRightTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProvider()
     {
-        return array(
-            array(0, 5, 0),
-            array(1, 5, 0),
-            array(5, 2, 1),
-            array(-1, 5, -1),
-            array(1.4, 5, 0),
-            array(-19.7, 1, -10),
-            array(true, true, 0),
-            array(false, true, 0),
-            array(true, false, 1),
-            array(false, false, 0),
-        );
+        return [
+            [0, 5, 0],
+            [1, 5, 0],
+            [5, 2, 1],
+            [-1, 5, -1],
+            [1.4, 5, 0],
+            [-19.7, 1, -10],
+            [true, true, 0],
+            [false, true, 0],
+            [true, false, 1],
+            [false, false, 0],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/BinaryOp/EqualTest.php
+++ b/tests/PHPSA/Compiler/Expression/BinaryOp/EqualTest.php
@@ -17,32 +17,32 @@ class EqualTest extends \Tests\PHPSA\TestCase
      */
     public function providerForStaticEqualsTrue()
     {
-        return array(
-            array(-1, -1),
-            array(-1, -1.0),
-            array(-5, -5),
-            array(-5, -5.0),
-            array(-5.0, -5),
-            array(-150, -150),
-            array(-150.0, -150),
-            array(-150, -150.0),
-            array(150, 150),
-            array(150, 150.0),
-            array(150.0, 150),
-            array(150.0, 150.0),
+        return [
+            [-1, -1],
+            [-1, -1.0],
+            [-5, -5],
+            [-5, -5.0],
+            [-5.0, -5],
+            [-150, -150],
+            [-150.0, -150],
+            [-150, -150.0],
+            [150, 150],
+            [150, 150.0],
+            [150.0, 150],
+            [150.0, 150.0],
             //boolean true
-            array(true, true),
-            array(true, 1),
-            array(1, true),
+            [true, true],
+            [true, 1],
+            [1, true],
             // boolean false
-            array(false, false),
-            array(false, 0),
-            array(0, false),
+            [false, false],
+            [false, 0],
+            [0, false],
             // empty arrays
-            array(array(), false),
-            array(false, array()),
-            array(array(), array()),
-        );
+            [[], false],
+            [false, []],
+            [[], []],
+        ];
     }
 
     /**
@@ -71,19 +71,19 @@ class EqualTest extends \Tests\PHPSA\TestCase
      */
     public function providerForStaticEqualsFalse()
     {
-        return array(
-            array(-1, 150),
-            array(-1, 1),
-            array(0, 1),
-            array(1, 0),
-            array(true, 0),
-            array(0, true),
-            array(false, true),
-            array(false, 1),
-            array(1, false),
-            array(true, array()),
-            array(array(), true),
-        );
+        return [
+            [-1, 150],
+            [-1, 1],
+            [0, 1],
+            [1, 0],
+            [true, 0],
+            [0, true],
+            [false, true],
+            [false, 1],
+            [1, false],
+            [true, []],
+            [[], true],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/BinaryOp/IdenticalTest.php
+++ b/tests/PHPSA/Compiler/Expression/BinaryOp/IdenticalTest.php
@@ -17,13 +17,13 @@ class IndenticalTest extends \Tests\PHPSA\TestCase
      */
     public function providerForStaticIntToIntCases()
     {
-        return array(
-            array(-1, -1),
-            array(-5, -5),
-            array(-150, -150),
-            array(150, 150),
-            array(150, 150),
-        );
+        return [
+            [-1, -1],
+            [-5, -5],
+            [-150, -150],
+            [150, 150],
+            [150, 150],
+        ];
     }
 
     /**
@@ -82,13 +82,13 @@ class IndenticalTest extends \Tests\PHPSA\TestCase
 
     public function providerForStaticIntToFloatCases()
     {
-        return array(
-            array(-1, -1.0),
-            array(-5, -5.0),
-            array(-150, -150.0),
-            array(150, 150.0),
-            array(150, 150.0),
-        );
+        return [
+            [-1, -1.0],
+            [-5, -5.0],
+            [-150, -150.0],
+            [150, 150.0],
+            [150, 150.0],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/BinaryOp/NotEqualTest.php
+++ b/tests/PHPSA/Compiler/Expression/BinaryOp/NotEqualTest.php
@@ -13,18 +13,18 @@ class NotEqualTest extends \Tests\PHPSA\TestCase
      */
     public function providerForStaticEqualsTrue()
     {
-        return array(
-            array(-1, -2),
+        return [
+            [-1, -2],
             //boolean true
-            array(true, false),
-            array(true, 0),
-            array(0, true),
+            [true, false],
+            [true, 0],
+            [0, true],
             // boolean false
-            array(false, true),
-            array(false, 1),
-            array(1, false)
+            [false, true],
+            [false, 1],
+            [1, false]
             //@todo arrays....
-        );
+        ];
     }
 
     /**
@@ -53,17 +53,17 @@ class NotEqualTest extends \Tests\PHPSA\TestCase
      */
     public function providerForStaticEqualsFalse()
     {
-        return array(
-            array(-1, -1),
-            array(1, 1),
-            array(1, 1),
-            array(0, 0),
-            array(true, 1),
-            array(1, true),
-            array(false, 0),
-            array(false, false)
+        return [
+            [-1, -1],
+            [1, 1],
+            [1, 1],
+            [0, 0],
+            [true, 1],
+            [1, true],
+            [false, 0],
+            [false, false]
             //@todo arrays....
-        );
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/BinaryOp/NotIdenticalTest.php
+++ b/tests/PHPSA/Compiler/Expression/BinaryOp/NotIdenticalTest.php
@@ -17,14 +17,14 @@ class NotIndenticalTest extends \Tests\PHPSA\TestCase
      */
     public function providerForStaticIntToIntCases()
     {
-        return array(
-            array(-1, -2),
-            array(-1, 0),
-            array(-5, -4),
-            array(-150, -151),
-            array(150, 151),
-            array(151, 150),
-        );
+        return [
+            [-1, -2],
+            [-1, 0],
+            [-5, -4],
+            [-150, -151],
+            [150, 151],
+            [151, 150],
+        ];
     }
 
     /**
@@ -83,13 +83,13 @@ class NotIndenticalTest extends \Tests\PHPSA\TestCase
 
     public function providerForStaticIntToFloatCases()
     {
-        return array(
-            array(-1, -1.0),
-            array(-5, -5.0),
-            array(-150, -150.0),
-            array(150, 150.0),
-            array(150, 150.0),
-        );
+        return [
+            [-1, -1.0],
+            [-5, -5.0],
+            [-150, -150.0],
+            [150, 150.0],
+            [150, 150.0],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/BinaryOp/SpaceShipTest.php
+++ b/tests/PHPSA/Compiler/Expression/BinaryOp/SpaceShipTest.php
@@ -13,17 +13,17 @@ class SpaceShipTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProvider()
     {
-        return array(
-            array(1, 1, 0),
-            array(1, 2, -1),
-            array(2, 1, 1),
-            array(true, false, 1),
-            array(true, 0, 1),
-            array(array(), array(), 0),
-            array(true, array(), 1),
-            array("a", "b", -1),
-            array("a", 2, -1),
-        );
+        return [
+            [1, 1, 0],
+            [1, 2, -1],
+            [2, 1, 1],
+            [true, false, 1],
+            [true, 0, 1],
+            [[], [], 0],
+            [true, [], 1],
+            ["a", "b", -1],
+            ["a", 2, -1],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Casts/ArrayCastTest.php
+++ b/tests/PHPSA/Compiler/Expression/Casts/ArrayCastTest.php
@@ -13,9 +13,9 @@ class ArrayCastTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProvider()
     {
-        return array(
-            array(array(), array()),
-        );
+        return [
+            [[], []],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Casts/BoolCastTest.php
+++ b/tests/PHPSA/Compiler/Expression/Casts/BoolCastTest.php
@@ -13,14 +13,14 @@ class BoolCastTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProvider()
     {
-        return array(
-            array(true, true),
-            array(0, false),
-            array(-1, true),
-            array(1.4, true),
-            array("a", true),
-            array(array(), false),
-        );
+        return [
+            [true, true],
+            [0, false],
+            [-1, true],
+            [1.4, true],
+            ["a", true],
+            [[], false],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Casts/DoubleCastTest.php
+++ b/tests/PHPSA/Compiler/Expression/Casts/DoubleCastTest.php
@@ -13,14 +13,14 @@ class DoubleCastTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProvider()
     {
-        return array(
-            array(true, 1.0),
-            array(0, 0.0),
-            array(-1, -1.0),
-            array(1.4, 1.4),
-            array("a", 0.0),
-            array(array(), 0.0),
-        );
+        return [
+            [true, 1.0],
+            [0, 0.0],
+            [-1, -1.0],
+            [1.4, 1.4],
+            ["a", 0.0],
+            [[], 0.0],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Casts/IntCastTest.php
+++ b/tests/PHPSA/Compiler/Expression/Casts/IntCastTest.php
@@ -13,14 +13,14 @@ class IntCastTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProvider()
     {
-        return array(
-            array(true, 1),
-            array(0, 0),
-            array(-1, -1),
-            array(1.4, 1),
-            array("a", 0),
-            array(array(), 0),
-        );
+        return [
+            [true, 1],
+            [0, 0],
+            [-1, -1],
+            [1.4, 1],
+            ["a", 0],
+            [[], 0],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Casts/StringCastTest.php
+++ b/tests/PHPSA/Compiler/Expression/Casts/StringCastTest.php
@@ -13,13 +13,13 @@ class StringCastTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProvider()
     {
-        return array(
-            array(true, "1"),
-            array(0, "0"),
-            array(-1, "-1"),
-            array(1.4, "1.4"),
-            array("a", "a"),
-        );
+        return [
+            [true, "1"],
+            [0, "0"],
+            [-1, "-1"],
+            [1.4, "1.4"],
+            ["a", "a"],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Operators/Arithmetical/AbstractDivMod.php
+++ b/tests/PHPSA/Compiler/Expression/Operators/Arithmetical/AbstractDivMod.php
@@ -29,19 +29,19 @@ abstract class AbstractDivMod extends \Tests\PHPSA\TestCase
      */
     public function divIntResultDataProvider()
     {
-        return array(
-            array(-1, -1),
-            array(-1, 1),
-            array(1, 1),
-            array(true, 1),
-            array(true, true),
-            array(1, true),
-            array(0, 1),
-            array(25, 25),
-            array(50, 50),
-            array(500, 50),
-            array(5000, 50)
-        );
+        return [
+            [-1, -1],
+            [-1, 1],
+            [1, 1],
+            [true, 1],
+            [true, true],
+            [1, true],
+            [0, 1],
+            [25, 25],
+            [50, 50],
+            [500, 50],
+            [5000, 50]
+        ];
     }
 
     /**
@@ -72,16 +72,16 @@ abstract class AbstractDivMod extends \Tests\PHPSA\TestCase
      */
     public function divFloatResultDataProvider()
     {
-        return array(
-            array(-1, -1.25, 0.8),
-            array(-1, 1.25, -0.8),
-            array(1, 1.25, 0.8),
-            array(true, 1.25, 0.8),
-            array(0, 1.25, 0.0),
-            array(25, 12.5, 2.0),
-            array(25, 6.25, 4.0),
-            array(25, 3.125, 8.0),
-        );
+        return [
+            [-1, -1.25, 0.8],
+            [-1, 1.25, -0.8],
+            [1, 1.25, 0.8],
+            [true, 1.25, 0.8],
+            [0, 1.25, 0.0],
+            [25, 12.5, 2.0],
+            [25, 6.25, 4.0],
+            [25, 3.125, 8.0],
+        ];
     }
 
     /**
@@ -114,15 +114,15 @@ abstract class AbstractDivMod extends \Tests\PHPSA\TestCase
      */
     public function divDoubleToDoubleResultDataProvider()
     {
-        return array(
-            array(-1.25, -1, 1.25),
-            array(1.25, -1, -1.25),
-            array(1.25, 1, 1.25),
-            array(1.25, true, 1.25),
-            array(12.5, 25, 1/2),
-            array(6.25, 25, 1/4),
-            array(3.125, 25, 1/8),
-        );
+        return [
+            [-1.25, -1, 1.25],
+            [1.25, -1, -1.25],
+            [1.25, 1, 1.25],
+            [1.25, true, 1.25],
+            [12.5, 25, 1/2],
+            [6.25, 25, 1/4],
+            [3.125, 25, 1/8],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Operators/Arithmetical/DivTest.php
+++ b/tests/PHPSA/Compiler/Expression/Operators/Arithmetical/DivTest.php
@@ -40,19 +40,19 @@ class DivTest extends AbstractDivMod
      */
     public function divIntResultDataProvider()
     {
-        return array(
-            array(-1, -1),
-            array(-1, 1),
-            array(1, 1),
-            array(true, 1),
-            array(true, true),
-            array(1, true),
-            array(0, 1),
-            array(25, 25),
-            array(50, 50),
-            array(500, 50),
-            array(5000, 50)
-        );
+        return [
+            [-1, -1],
+            [-1, 1],
+            [1, 1],
+            [true, 1],
+            [true, true],
+            [1, true],
+            [0, 1],
+            [25, 25],
+            [50, 50],
+            [500, 50],
+            [5000, 50]
+        ];
     }
 
     /**
@@ -81,16 +81,16 @@ class DivTest extends AbstractDivMod
      */
     public function divFloatResultDataProvider()
     {
-        return array(
-            array(-1, -1.25, 0.8),
-            array(-1, 1.25, -0.8),
-            array(1, 1.25, 0.8),
-            array(true, 1.25, 0.8),
-            array(0, 1.25, 0.0),
-            array(25, 12.5, 2.0),
-            array(25, 6.25, 4.0),
-            array(25, 3.125, 8.0),
-        );
+        return [
+            [-1, -1.25, 0.8],
+            [-1, 1.25, -0.8],
+            [1, 1.25, 0.8],
+            [true, 1.25, 0.8],
+            [0, 1.25, 0.0],
+            [25, 12.5, 2.0],
+            [25, 6.25, 4.0],
+            [25, 3.125, 8.0],
+        ];
     }
 
     /**
@@ -123,16 +123,16 @@ class DivTest extends AbstractDivMod
      */
     public function divDoubleToDoubleResultDataProvider()
     {
-        return array(
-            array(-1.25, -1, 1.25),
-            array(1.25, -1, -1.25),
-            array(1.25, 1, 1.25),
-            array(1.25, true, 1.25),
-            array(0.0, 1, 0.0),
-            array(12.5, 25, 1/2),
-            array(6.25, 25, 1/4),
-            array(3.125, 25, 1/8),
-        );
+        return [
+            [-1.25, -1, 1.25],
+            [1.25, -1, -1.25],
+            [1.25, 1, 1.25],
+            [1.25, true, 1.25],
+            [0.0, 1, 0.0],
+            [12.5, 25, 1/2],
+            [6.25, 25, 1/4],
+            [3.125, 25, 1/8],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Operators/Arithmetical/MinusTest.php
+++ b/tests/PHPSA/Compiler/Expression/Operators/Arithmetical/MinusTest.php
@@ -15,24 +15,24 @@ class MinusTest extends \Tests\PHPSA\TestCase
      */
     public function intToIntDataProvider()
     {
-        return array(
-            array(-1, -1, 0),
-            array(-1, 0, -1),
-            array(0, -1, 1),
-            array(-1, 2, -3),
-            array(2, -1, 3),
-            array(0, 0, 0),
-            array(0, 1, -1),
-            array(1, 0, 1),
-            array(1, 2, -1),
-            array(2, 1, 1),
-            array(25, 25, 0),
-            array(50, 25, 25),
-            array(50, -25, 75),
-            array(50, 50, 0),
-            array(50, -50, 100),
-            array(-50, -50, 0),
-        );
+        return [
+            [-1, -1, 0],
+            [-1, 0, -1],
+            [0, -1, 1],
+            [-1, 2, -3],
+            [2, -1, 3],
+            [0, 0, 0],
+            [0, 1, -1],
+            [1, 0, 1],
+            [1, 2, -1],
+            [2, 1, 1],
+            [25, 25, 0],
+            [50, 25, 25],
+            [50, -25, 75],
+            [50, 50, 0],
+            [50, -50, 100],
+            [-50, -50, 0],
+        ];
     }
 
     /**
@@ -64,14 +64,14 @@ class MinusTest extends \Tests\PHPSA\TestCase
      */
     public function resultDoubleDataProvider()
     {
-        return array(
-            array(-1, -1.0, 0.0),
-            array(-1.0, -1.0, 0.0),
-            array(3, 1.5, 1.5),
-            array(4.0, 2.0, 2.0),
-            array(2, 3.5, -1.5),
-            array(2.5, 3.5, -1.0),
-        );
+        return [
+            [-1, -1.0, 0.0],
+            [-1.0, -1.0, 0.0],
+            [3, 1.5, 1.5],
+            [4.0, 2.0, 2.0],
+            [2, 3.5, -1.5],
+            [2.5, 3.5, -1.0],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Operators/Arithmetical/MulTest.php
+++ b/tests/PHPSA/Compiler/Expression/Operators/Arithmetical/MulTest.php
@@ -15,19 +15,19 @@ class MulTest extends \Tests\PHPSA\TestCase
      */
     public function divIntResultDataProvider()
     {
-        return array(
-            array(-1, -1, 1),
-            array(-1, 1, -1),
-            array(1, 1, 1),
-            array(true, 1, 1),
-            array(true, true, 1),
-            array(1, true, 1),
-            array(0, 1, 0),
-            array(25, 25, 25*25),
-            array(50, 50, 50*50),
-            array(500, 50, 25000),
-            array(5000, 50, 250000)
-        );
+        return [
+            [-1, -1, 1],
+            [-1, 1, -1],
+            [1, 1, 1],
+            [true, 1, 1],
+            [true, true, 1],
+            [1, true, 1],
+            [0, 1, 0],
+            [25, 25, 25*25],
+            [50, 50, 50*50],
+            [500, 50, 25000],
+            [5000, 50, 250000]
+        ];
     }
 
     /**
@@ -59,16 +59,16 @@ class MulTest extends \Tests\PHPSA\TestCase
      */
     public function floatResultDataProvider()
     {
-        return array(
-            array(-1, -1.25, 1*1.25),
-            array(-1, 1.25, -(1*1.25)),
-            array(1, 1.25, 1*1.25),
-            array(true, 1.25, 1.25),
-            array(0, 1.25, 0.0),
-            array(25, 12.5, 25*12.5),
-            array(25, 6.25, 25*6.25),
-            array(25, 3.125, 25*3.125),
-        );
+        return [
+            [-1, -1.25, 1*1.25],
+            [-1, 1.25, -(1*1.25)],
+            [1, 1.25, 1*1.25],
+            [true, 1.25, 1.25],
+            [0, 1.25, 0.0],
+            [25, 12.5, 25*12.5],
+            [25, 6.25, 25*6.25],
+            [25, 3.125, 25*3.125],
+        ];
     }
 
     /**
@@ -100,15 +100,15 @@ class MulTest extends \Tests\PHPSA\TestCase
      */
     public function doubleOnDoubleResultDataProvider()
     {
-        return array(
-            array(-1.25, -1, 1.25),
-            array(1.25, -1, -1.25),
-            array(1.25, 1, 1.25),
-            array(1.25, true, 1.25),
-            array(12.5, 25, 312.5),
-            array(6.25, 25, 156.25),
-            array(3.125, 25, 78.125),
-        );
+        return [
+            [-1.25, -1, 1.25],
+            [1.25, -1, -1.25],
+            [1.25, 1, 1.25],
+            [1.25, true, 1.25],
+            [12.5, 25, 312.5],
+            [6.25, 25, 156.25],
+            [3.125, 25, 78.125],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Operators/Arithmetical/PlusTest.php
+++ b/tests/PHPSA/Compiler/Expression/Operators/Arithmetical/PlusTest.php
@@ -15,20 +15,20 @@ class PlusTest extends \Tests\PHPSA\TestCase
      */
     public function intToIntDataProvider()
     {
-        return array(
-            array(-1, -1, -2),
-            array(-1, 0, -1),
-            array(0, -1, -1),
-            array(-1, 2, 1),
-            array(2, -1, 1),
-            array(0, 0, 0),
-            array(0, 1, 1),
-            array(1, 0, 1),
-            array(1, 2, 3),
-            array(2, 1, 3),
-            array(25, 25, 50),
-            array(50, 50, 100),
-        );
+        return [
+            [-1, -1, -2],
+            [-1, 0, -1],
+            [0, -1, -1],
+            [-1, 2, 1],
+            [2, -1, 1],
+            [0, 0, 0],
+            [0, 1, 1],
+            [1, 0, 1],
+            [1, 2, 3],
+            [2, 1, 3],
+            [25, 25, 50],
+            [50, 50, 100],
+        ];
     }
 
     /**
@@ -38,17 +38,17 @@ class PlusTest extends \Tests\PHPSA\TestCase
      */
     public function intToFloatDataProvider()
     {
-        return array(
-            array(1, -1.5, -0.5),
-            array(1, -1.0, 0.0),
-            array(-1, -1.0, -2.0),
-            array(-1, -2.55, -3.55),
-            array(1, 1.5, 2.5),
-            array(1, 2.5, 3.5),
-            array(1, 4.5, 5.5),
-            array(1, 4.75, 5.75),
-            array(25, 24.75, 49.75)
-        );
+        return [
+            [1, -1.5, -0.5],
+            [1, -1.0, 0.0],
+            [-1, -1.0, -2.0],
+            [-1, -2.55, -3.55],
+            [1, 1.5, 2.5],
+            [1, 2.5, 3.5],
+            [1, 4.5, 5.5],
+            [1, 4.75, 5.75],
+            [25, 24.75, 49.75]
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Operators/Arithmetical/PowTest.php
+++ b/tests/PHPSA/Compiler/Expression/Operators/Arithmetical/PowTest.php
@@ -15,19 +15,19 @@ class PowTest extends \Tests\PHPSA\TestCase
      */
     public function powResultIntDataProvider()
     {
-        return array(
-            array(2, 2, 4),
-            array(true, 2, 1),
-            array(3, true, 3),
-            array(true, true, 1),
-            array(2, 0, 1),
-            array(false, 3, 0),
-            array(2, false, 1),
-            array(false, false, 1),
-            array(0, 0, 1),
-            array(0, 3, 0),
-            array(true, false, 1),
-        );
+        return [
+            [2, 2, 4],
+            [true, 2, 1],
+            [3, true, 3],
+            [true, true, 1],
+            [2, 0, 1],
+            [false, 3, 0],
+            [2, false, 1],
+            [false, false, 1],
+            [0, 0, 1],
+            [0, 3, 0],
+            [true, false, 1],
+        ];
     }
 
     /**
@@ -56,16 +56,16 @@ class PowTest extends \Tests\PHPSA\TestCase
      */
     public function powResultDoubleDataProvider()
     {
-        return array(
-            array(2, -2, 0.25),
-            array(1.5, 2, 2.25),
-            array(1, 1.5, 1.0),
-            array(100, 2.5, 100000.0),
-            array(true, 1.5, 1.0),
-            array(false, 1.5, 0.0),
-            array(1.5, false, 1.0),
-            array(1.5, true, 1.5),
-        );
+        return [
+            [2, -2, 0.25],
+            [1.5, 2, 2.25],
+            [1, 1.5, 1.0],
+            [100, 2.5, 100000.0],
+            [true, 1.5, 1.0],
+            [false, 1.5, 0.0],
+            [1.5, false, 1.0],
+            [1.5, true, 1.5],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Operators/Bitwise/BitwiseAndTest.php
+++ b/tests/PHPSA/Compiler/Expression/Operators/Bitwise/BitwiseAndTest.php
@@ -13,18 +13,18 @@ class BitwiseAndTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProvider()
     {
-        return array(
-            array(0, 5, 0),
-            array(1, 5, 1),
-            array(4, 5, 4),
-            array(-1, 5, 5),
-            array(1.4, 5, 1),
-            array(-19.7, 1, 1),
-            array(true, true, 1),
-            array(false, true, 0),
-            array(true, false, 0),
-            array(false, false, 0),
-        );
+        return [
+            [0, 5, 0],
+            [1, 5, 1],
+            [4, 5, 4],
+            [-1, 5, 5],
+            [1.4, 5, 1],
+            [-19.7, 1, 1],
+            [true, true, 1],
+            [false, true, 0],
+            [true, false, 0],
+            [false, false, 0],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Operators/Bitwise/BitwiseNotTest.php
+++ b/tests/PHPSA/Compiler/Expression/Operators/Bitwise/BitwiseNotTest.php
@@ -13,12 +13,12 @@ class BitwiseNotTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProvider()
     {
-        return array(
-            array(1, -2),
-            array(-1, 0),
-            array(1.4,-2),
-            array(-2.7, 1),
-        );
+        return [
+            [1, -2],
+            [-1, 0],
+            [1.4,-2],
+            [-2.7, 1],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Operators/Bitwise/BitwiseOrTest.php
+++ b/tests/PHPSA/Compiler/Expression/Operators/Bitwise/BitwiseOrTest.php
@@ -13,18 +13,18 @@ class BitwiseOrTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProvider()
     {
-        return array(
-            array(0, 5, 5),
-            array(1, 5, 5),
-            array(4, 5, 5),
-            array(-1, 5, -1),
-            array(1.4, 5, 5),
-            array(-19.7, 1, -19),
-            array(true, true, 1),
-            array(false, true, 1),
-            array(true, false, 1),
-            array(false, false, 0),
-        );
+        return [
+            [0, 5, 5],
+            [1, 5, 5],
+            [4, 5, 5],
+            [-1, 5, -1],
+            [1.4, 5, 5],
+            [-19.7, 1, -19],
+            [true, true, 1],
+            [false, true, 1],
+            [true, false, 1],
+            [false, false, 0],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Operators/Bitwise/BitwiseXorTest.php
+++ b/tests/PHPSA/Compiler/Expression/Operators/Bitwise/BitwiseXorTest.php
@@ -13,18 +13,18 @@ class BitwiseXorTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProvider()
     {
-        return array(
-            array(0, 5, 5),
-            array(1, 5, 4),
-            array(4, 5, 1),
-            array(-1, 5, -6),
-            array(1.4, 5, 4),
-            array(-19.7, 1, -20),
-            array(true, true, 0),
-            array(false, true, 1),
-            array(true, false, 1),
-            array(false, false, 0),
-        );
+        return [
+            [0, 5, 5],
+            [1, 5, 4],
+            [4, 5, 1],
+            [-1, 5, -6],
+            [1.4, 5, 4],
+            [-19.7, 1, -20],
+            [true, true, 0],
+            [false, true, 1],
+            [true, false, 1],
+            [false, false, 0],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Operators/Bitwise/ShiftLeftTest.php
+++ b/tests/PHPSA/Compiler/Expression/Operators/Bitwise/ShiftLeftTest.php
@@ -13,18 +13,18 @@ class ShiftLeftTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProvider()
     {
-        return array(
-            array(0, 5, 0),
-            array(1, 5, 32),
-            array(4, 5, 128),
-            array(-1, 5, -32),
-            array(1.4, 5, 32),
-            array(-19.7, 2, -76),
-            array(true, true, 2),
-            array(false, true, 0),
-            array(true, false, 1),
-            array(false, false, 0),
-        );
+        return [
+            [0, 5, 0],
+            [1, 5, 32],
+            [4, 5, 128],
+            [-1, 5, -32],
+            [1.4, 5, 32],
+            [-19.7, 2, -76],
+            [true, true, 2],
+            [false, true, 0],
+            [true, false, 1],
+            [false, false, 0],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Operators/Bitwise/ShiftRightTest.php
+++ b/tests/PHPSA/Compiler/Expression/Operators/Bitwise/ShiftRightTest.php
@@ -13,18 +13,18 @@ class ShiftRightTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProvider()
     {
-        return array(
-            array(0, 5, 0),
-            array(1, 5, 0),
-            array(5, 2, 1),
-            array(-1, 5, -1),
-            array(1.4, 5, 0),
-            array(-19.7, 1, -10),
-            array(true, true, 0),
-            array(false, true, 0),
-            array(true, false, 1),
-            array(false, false, 0),
-        );
+        return [
+            [0, 5, 0],
+            [1, 5, 0],
+            [5, 2, 1],
+            [-1, 5, -1],
+            [1.4, 5, 0],
+            [-19.7, 1, -10],
+            [true, true, 0],
+            [false, true, 0],
+            [true, false, 1],
+            [false, false, 0],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Operators/Comparison/BaseTestCase.php
+++ b/tests/PHPSA/Compiler/Expression/Operators/Comparison/BaseTestCase.php
@@ -13,18 +13,18 @@ abstract class BaseTestCase extends \Tests\PHPSA\TestCase
      */
     public function smallerDataProvider()
     {
-        return array(
-            array(-1, -1),
-            array(-2, -1),
-            array(-3, -1),
-            array(-50, -1),
-            array(1, 2),
-            array(1, 5),
-            array(6, 5),
-            array(6, 6),
-            array(5, 6),
-            array(5, 5),
-        );
+        return [
+            [-1, -1],
+            [-2, -1],
+            [-3, -1],
+            [-50, -1],
+            [1, 2],
+            [1, 5],
+            [6, 5],
+            [6, 6],
+            [5, 6],
+            [5, 5],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Operators/ConcatTest.php
+++ b/tests/PHPSA/Compiler/Expression/Operators/ConcatTest.php
@@ -15,20 +15,20 @@ class ConcatTest extends \Tests\PHPSA\TestCase
      */
     public function concatResultDataProvider()
     {
-        return array(
-            array(2, 2, "22"),
-            array(true, "a", "1a"),
-            array("a", true, "a1"),
-            array(true, true, "11"),
-            array(-1, 1, "-11"),
-            array(false, 3, "3"), // 0 at beginning is dropped
-            array(false, true, "1"),
-            array(0, -1, "0-1"),
-            array(1.5, -1, "1.5-1"),
-            array(true, -0.5, "1-0.5"),
-            array(false, false, ""),
-            array(true, false, "1"),
-        );
+        return [
+            [2, 2, "22"],
+            [true, "a", "1a"],
+            ["a", true, "a1"],
+            [true, true, "11"],
+            [-1, 1, "-11"],
+            [false, 3, "3"], // 0 at beginning is dropped
+            [false, true, "1"],
+            [0, -1, "0-1"],
+            [1.5, -1, "1.5-1"],
+            [true, -0.5, "1-0.5"],
+            [false, false, ""],
+            [true, false, "1"],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Operators/Logical/BooleanAndTest.php
+++ b/tests/PHPSA/Compiler/Expression/Operators/Logical/BooleanAndTest.php
@@ -13,22 +13,22 @@ class BooleanAndTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProvider()
     {
-        return array(
-            array(true, true, true),
-            array(false, true, false),
-            array(true, false, false),
-            array(false, false, false),
-            array(null, null, false),
-            array(true, null, false),
-            array(null, true, false),
-            array(1, true, true),
-            array(1.4, true, true),
-            array(1, false, false),
-            array(-1, true, true),
-            array("a", true, true),
-            array(array(), array(), false),
-            array(array(), "a", false),
-        );
+        return [
+            [true, true, true],
+            [false, true, false],
+            [true, false, false],
+            [false, false, false],
+            [null, null, false],
+            [true, null, false],
+            [null, true, false],
+            [1, true, true],
+            [1.4, true, true],
+            [1, false, false],
+            [-1, true, true],
+            ["a", true, true],
+            [[], [], false],
+            [[], "a", false],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Operators/Logical/BooleanNotTest.php
+++ b/tests/PHPSA/Compiler/Expression/Operators/Logical/BooleanNotTest.php
@@ -17,16 +17,16 @@ class BooleanNotTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProvider()
     {
-        return array(
-            array(true, false),
-            array(false, true),
-            array(1, false),
-            array(-1, false),
-            array(1.4, false),
-            array(null, true),
-            array("a", false),
-            array(array(), true),
-        );
+        return [
+            [true, false],
+            [false, true],
+            [1, false],
+            [-1, false],
+            [1.4, false],
+            [null, true],
+            ["a", false],
+            [[], true],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Operators/Logical/BooleanOrTest.php
+++ b/tests/PHPSA/Compiler/Expression/Operators/Logical/BooleanOrTest.php
@@ -13,24 +13,24 @@ class BooleanOrTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProvider()
     {
-        return array(
-            array(true, true, true),
-            array(true, false, true),
-            array(false, true, true),
-            array(false, false, false),
-            array(null, false, false),
-            array(false, null, false),
-            array(null, null, false),
-            array(true, null, true),
-            array(null, true, true),
-            array(1, true, true),
-            array(1.4, false, true),
-            array(1, false, true),
-            array(-1, false, true),
-            array("a", false, true),
-            array(array(), array(), false),
-            array(array(), "a", true),
-        );
+        return [
+            [true, true, true],
+            [true, false, true],
+            [false, true, true],
+            [false, false, false],
+            [null, false, false],
+            [false, null, false],
+            [null, null, false],
+            [true, null, true],
+            [null, true, true],
+            [1, true, true],
+            [1.4, false, true],
+            [1, false, true],
+            [-1, false, true],
+            ["a", false, true],
+            [[], [], false],
+            [[], "a", true],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Operators/Logical/LogicalAndTest.php
+++ b/tests/PHPSA/Compiler/Expression/Operators/Logical/LogicalAndTest.php
@@ -13,22 +13,22 @@ class LogicalAndTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProvider()
     {
-        return array(
-            array(true, true, true),
-            array(false, true, false),
-            array(true, false, false),
-            array(false, false, false),
-            array(null, null, false),
-            array(true, null, false),
-            array(null, true, false),
-            array(1, true, true),
-            array(1.4, true, true),
-            array(1, false, false),
-            array(-1, true, true),
-            array("a", true, true),
-            array(array(), array(), false),
-            array(array(), "a", false),
-        );
+        return [
+            [true, true, true],
+            [false, true, false],
+            [true, false, false],
+            [false, false, false],
+            [null, null, false],
+            [true, null, false],
+            [null, true, false],
+            [1, true, true],
+            [1.4, true, true],
+            [1, false, false],
+            [-1, true, true],
+            ["a", true, true],
+            [[], [], false],
+            [[], "a", false],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Operators/Logical/LogicalOrTest.php
+++ b/tests/PHPSA/Compiler/Expression/Operators/Logical/LogicalOrTest.php
@@ -13,24 +13,24 @@ class LogicalOrTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProvider()
     {
-        return array(
-            array(true, true, true),
-            array(true, false, true),
-            array(false, true, true),
-            array(false, false, false),
-            array(null, false, false),
-            array(false, null, false),
-            array(null, null, false),
-            array(true, null, true),
-            array(null, true, true),
-            array(1, true, true),
-            array(1.4, false, true),
-            array(1, false, true),
-            array(-1, false, true),
-            array("a", false, true),
-            array(array(), array(), false),
-            array(array(), "a", true),
-        );
+        return [
+            [true, true, true],
+            [true, false, true],
+            [false, true, true],
+            [false, false, false],
+            [null, false, false],
+            [false, null, false],
+            [null, null, false],
+            [true, null, true],
+            [null, true, true],
+            [1, true, true],
+            [1.4, false, true],
+            [1, false, true],
+            [-1, false, true],
+            ["a", false, true],
+            [[], [], false],
+            [[], "a", true],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Operators/Logical/LogicalXorTest.php
+++ b/tests/PHPSA/Compiler/Expression/Operators/Logical/LogicalXorTest.php
@@ -13,24 +13,24 @@ class LogicalXorTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProvider()
     {
-        return array(
-            array(true, true, false),
-            array(true, false, true),
-            array(false, true, true),
-            array(false, false, false),
-            array(null, false, false),
-            array(false, null, false),
-            array(null, null, false),
-            array(true, null, true),
-            array(null, true, true),
-            array(1, true, false),
-            array(1.4, false, true),
-            array(1, false, true),
-            array(-1, false, true),
-            array("a", false, true),
-            array(array(), array(), false),
-            array(array(), "a", true),
-        );
+        return [
+            [true, true, false],
+            [true, false, true],
+            [false, true, true],
+            [false, false, false],
+            [null, false, false],
+            [false, null, false],
+            [null, null, false],
+            [true, null, true],
+            [null, true, true],
+            [1, true, false],
+            [1.4, false, true],
+            [1, false, true],
+            [-1, false, true],
+            ["a", false, true],
+            [[], [], false],
+            [[], "a", true],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Operators/PostDecTest.php
+++ b/tests/PHPSA/Compiler/Expression/Operators/PostDecTest.php
@@ -18,12 +18,12 @@ class PostDecTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProviderForSuccess()
     {
-        return array(
-            array(-1),
-            array(1),
-            array(99),
-            array(0),
-        );
+        return [
+            [-1],
+            [1],
+            [99],
+            [0],
+        ];
     }
 
     /**
@@ -53,12 +53,12 @@ class PostDecTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProviderForSuccessDouble()
     {
-        return array(
-            array(-1.4),
-            array(1.4),
-            array(99.4),
-            array(0.4),
-        );
+        return [
+            [-1.4],
+            [1.4],
+            [99.4],
+            [0.4],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Operators/PostIncTest.php
+++ b/tests/PHPSA/Compiler/Expression/Operators/PostIncTest.php
@@ -18,12 +18,12 @@ class PostIncTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProviderForSuccess()
     {
-        return array(
-            array(-1),
-            array(1),
-            array(99),
-            array(0),
-        );
+        return [
+            [-1],
+            [1],
+            [99],
+            [0],
+        ];
     }
 
     /**
@@ -53,12 +53,12 @@ class PostIncTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProviderForSuccessDouble()
     {
-        return array(
-            array(-1.4),
-            array(1.4),
-            array(99.4),
-            array(0.4),
-        );
+        return [
+            [-1.4],
+            [1.4],
+            [99.4],
+            [0.4],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Operators/PreDecTest.php
+++ b/tests/PHPSA/Compiler/Expression/Operators/PreDecTest.php
@@ -18,12 +18,12 @@ class PreDecTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProviderForSuccess()
     {
-        return array(
-            array(-1),
-            array(1),
-            array(99),
-            array(0),
-        );
+        return [
+            [-1],
+            [1],
+            [99],
+            [0],
+        ];
     }
 
     /**
@@ -53,12 +53,12 @@ class PreDecTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProviderForSuccessDouble()
     {
-        return array(
-            array(-1.4),
-            array(1.4),
-            array(99.4),
-            array(0.4),
-        );
+        return [
+            [-1.4],
+            [1.4],
+            [99.4],
+            [0.4],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Operators/PreIncTest.php
+++ b/tests/PHPSA/Compiler/Expression/Operators/PreIncTest.php
@@ -18,12 +18,12 @@ class PreIncTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProviderForSuccess()
     {
-        return array(
-            array(-1),
-            array(1),
-            array(99),
-            array(0),
-        );
+        return [
+            [-1],
+            [1],
+            [99],
+            [0],
+        ];
     }
 
     /**
@@ -53,12 +53,12 @@ class PreIncTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProviderForSuccessDouble()
     {
-        return array(
-            array(-1.4),
-            array(1.4),
-            array(99.4),
-            array(0.4),
-        );
+        return [
+            [-1.4],
+            [1.4],
+            [99.4],
+            [0.4],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Operators/UnaryMinusTest.php
+++ b/tests/PHPSA/Compiler/Expression/Operators/UnaryMinusTest.php
@@ -17,16 +17,16 @@ class UnaryMinusTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProviderForSuccess()
     {
-        return array(
-            array(-1),
-            array(1),
-            array(true),
-            array(false),
-            array("test string"),
-            array("10test string"),
-            array(""),
-            array(null),
-        );
+        return [
+            [-1],
+            [1],
+            [true],
+            [false],
+            ["test string"],
+            ["10test string"],
+            [""],
+            [null],
+        ];
     }
 
     /**
@@ -49,9 +49,9 @@ class UnaryMinusTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProviderForUnsupported()
     {
-        return array(
-            array([]),
-        );
+        return [
+            [[]],
+        ];
     }
 
     /**

--- a/tests/PHPSA/Compiler/Expression/Operators/UnaryPlusTest.php
+++ b/tests/PHPSA/Compiler/Expression/Operators/UnaryPlusTest.php
@@ -17,16 +17,16 @@ class UnaryPlusTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProviderForSuccess()
     {
-        return array(
-            array(-1),
-            array(1),
-            array(true),
-            array(false),
-            array("test string"),
-            array("10test string"),
-            array(""),
-            array(null),
-        );
+        return [
+            [-1],
+            [1],
+            [true],
+            [false],
+            ["test string"],
+            ["10test string"],
+            [""],
+            [null],
+        ];
     }
 
     /**
@@ -49,9 +49,9 @@ class UnaryPlusTest extends \Tests\PHPSA\TestCase
      */
     public function getDataProviderForUnsupported()
     {
-        return array(
-            array([]),
-        );
+        return [
+            [[]],
+        ];
     }
 
     /**


### PR DESCRIPTION
Hey!

Type: code quality

Link to issue:

This pull request affects the following components **(please check boxes):**

* [ ] Core
* [ ] Analyzer
* [ ] Compiler
* [ ] Control Flow Graph
* [ ] Documentation

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/ovr/phpsa/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Changed all data providers to use array short definition

