### PR TITLE
Fixed alias name type

### DIFF
--- a/src/Definition/FileParser.php
+++ b/src/Definition/FileParser.php
@@ -110,13 +110,13 @@ class FileParser
             if ($statement instanceof Node\Stmt\Use_) {
                 if (count($statement->uses) > 0) {
                     foreach ($statement->uses as $use) {
-                        $aliasManager->add($use->name->parts);
+                        $aliasManager->add((string)$use->name);
                     }
                 }
             } elseif ($statement instanceof Node\Stmt\GroupUse) {
                 if (count($statement->uses) > 0) {
                     foreach ($statement->uses as $use) {
-                        $aliasManager->add($statement->prefix . $use->name->parts);
+                        $aliasManager->add($statement->prefix->toString() . '\\' . $use->name->toString());
                     }
                 }
             } elseif ($statement instanceof Node\Stmt\Trait_) {


### PR DESCRIPTION
AliasManager::add(string)

```php
use \D\{F, G\H, I as J};
```

PHP Notice:  Array to string conversion in src/Definition/FileParser.php on line 119
