### PR TITLE
Fixed false positives [missing_break_statement] throw, continue

### DIFF
--- a/src/Analyzer/Pass/Statement/MissingBreakStatement.php
+++ b/src/Analyzer/Pass/Statement/MissingBreakStatement.php
@@ -57,6 +57,7 @@ class MissingBreakStatement implements Pass\AnalyzerPassInterface
      */
     private function checkCaseStatement(Stmt\Case_ $case, Context $context)
     {
+        $stmtsCount = count($case->stmts);
         /*
          * switch(…) {
          *     case 41:
@@ -65,20 +66,14 @@ class MissingBreakStatement implements Pass\AnalyzerPassInterface
          *         return 'the truth, or almost.';
          * }
          */
-        if (!$case->stmts) {
+        if ($stmtsCount === 0) {
             return false;
         }
 
-        foreach ($case->stmts as $node) {
-            // look for a break statement
-            if ($node instanceof Stmt\Break_) {
-                return false;
-            }
-
-            // or for a return
-            if ($node instanceof Stmt\Return_) {
-                return false;
-            }
+        $last = $case->stmts[$stmtsCount - 1];
+        if ($last instanceof Stmt\Break_ || $last instanceof Stmt\Return_
+        || $last instanceof Stmt\Throw_ || $last instanceof Stmt\Continue_) {
+            return false;
         }
 
         $context->notice(

--- a/tests/analyze-fixtures/Statement/MissingBreakStatement.php
+++ b/tests/analyze-fixtures/Statement/MissingBreakStatement.php
@@ -103,6 +103,38 @@ class MissingBreakStatement
 
         return $value;
     }
+
+    /**
+     * @return string
+     */
+    public function testValidSwitchWithThrowContinue()
+    {
+        switch (30) {
+            case 1:
+                $value = 'bar';
+                break;
+            case 2:
+                {
+                    $value = 'baz';
+                    break;
+                }
+            case 3:
+                $value = 'missing "break" statement here';
+                if (mt_rand() % 2) {
+                    break;
+                }
+            case 4:
+                $value = 'throw';
+                throw new \Exception();
+            case 5:
+                $value = 'continue';
+                continue 1;
+            default:
+                $value = 'default';
+        }
+
+        return $value;
+    }
 }
 ?>
 ----------------------------
@@ -120,5 +152,11 @@ PHPSA\Analyzer\Pass\Statement\MissingBreakStatement
         "message":"Missing \"break\" statement",
         "file":"MissingBreakStatement.php",
         "line":97
+    },
+    {
+        "type":"missing_break_statement",
+        "message":"Missing \"break\" statement",
+        "file":"MissingBreakStatement.php",
+        "line":120
     }
 ]


### PR DESCRIPTION
```php
<?php
function f(int $a)
{
    switch ($a) {
        case 4: //< Detect => !!! NG !!!
            ++$a;
            continue 1;
        case 5: //< Detect => !!! NG !!!
            ++$a;
            throw new \Exception();
        default:
            ++$a;
    }
}
```
