### PR TITLE
Improved #281 Reference to deprecated property of PhpParser3.0.2

### DIFF
--- a/src/Compiler/Expression/BinaryOp/Coalesce.php
+++ b/src/Compiler/Expression/BinaryOp/Coalesce.php
@@ -7,7 +7,6 @@ use PHPSA\Context;
 use PHPSA\Compiler\Expression;
 use PHPSA\Compiler\Expression\AbstractExpressionCompiler;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Name;
 
 class Coalesce extends AbstractExpressionCompiler
 {
@@ -23,13 +22,7 @@ class Coalesce extends AbstractExpressionCompiler
     protected function compile($expr, Context $context)
     {
         if ($expr->left instanceof Variable) {
-            $varName = $expr->left->name;
-
-            if ($varName instanceof Name) {
-                $varName = $varName->parts[0];
-            }
-
-            $variable = $context->getSymbol($varName);
+            $variable = $context->getSymbol((string)$expr->left->name);
 
             if ($variable) {
                 $variable->incUse();

--- a/src/Compiler/Expression/EmptyOp.php
+++ b/src/Compiler/Expression/EmptyOp.php
@@ -7,7 +7,6 @@ use PHPSA\Context;
 use PHPSA\Compiler\Expression;
 use PHPSA\Compiler\Expression\AbstractExpressionCompiler;
 use PhpParser\Node\Expr\Variable as VariableNode;
-use PhpParser\Node\Name;
 
 class EmptyOp extends AbstractExpressionCompiler
 {
@@ -23,13 +22,7 @@ class EmptyOp extends AbstractExpressionCompiler
     protected function compile($expr, Context $context)
     {
         if ($expr->expr instanceof VariableNode) {
-            $varName = $expr->expr->name;
-
-            if ($varName instanceof Name) {
-                $varName = $varName->parts[0];
-            }
-
-            $variable = $context->getSymbol($varName);
+            $variable = $context->getSymbol((string)$expr->expr->name);
 
             if ($variable) {
                 $variable->incUse();

--- a/src/Compiler/Expression/FunctionCall.php
+++ b/src/Compiler/Expression/FunctionCall.php
@@ -67,7 +67,7 @@ class FunctionCall extends AbstractExpressionCompiler
         if (!$exists) {
             $context->notice(
                 'language_error',
-                sprintf('Function %s() does not exist', $expr->name->parts[0]),
+                sprintf('Function %s() does not exist', (string)$expr->name),
                 $expr
             );
         } else {

--- a/src/Compiler/Expression/IssetOp.php
+++ b/src/Compiler/Expression/IssetOp.php
@@ -7,7 +7,6 @@ use PHPSA\Context;
 use PHPSA\Compiler\Expression;
 use PHPSA\Compiler\Expression\AbstractExpressionCompiler;
 use PhpParser\Node\Expr\Variable as VariableNode;
-use PhpParser\Node\Name;
 
 class IssetOp extends AbstractExpressionCompiler
 {
@@ -26,13 +25,7 @@ class IssetOp extends AbstractExpressionCompiler
 
         foreach ($expr->vars as $var) {
             if ($var instanceof VariableNode) {
-                $varName = $var->name;
-
-                if ($varName instanceof Name) {
-                    $varName = $varName->parts[0];
-                }
-
-                $variable = $context->getSymbol($varName);
+                $variable = $context->getSymbol((string)$var->name);
 
                 if ($variable) {
                     $variable->incUse();

--- a/src/Compiler/Expression/Operators/NewOp.php
+++ b/src/Compiler/Expression/Operators/NewOp.php
@@ -25,8 +25,6 @@ class NewOp extends AbstractExpressionCompiler
     protected function compile($expr, Context $context)
     {
         if ($expr->class instanceof Node\Name) {
-            $name = $expr->class->parts[0];
-
             $arguments = [];
 
             if (count($expr->args) > 0) {
@@ -34,6 +32,7 @@ class NewOp extends AbstractExpressionCompiler
                     $arguments[] = $context->getExpressionCompiler()->compile($argument->value);
                 }
             } else {
+                $name = (string)$expr->class;
                 if (class_exists($name, true)) {
                     return new CompiledExpression(CompiledExpression::OBJECT, new $name());
                 }

--- a/src/Compiler/Expression/Operators/PostDec.php
+++ b/src/Compiler/Expression/Operators/PostDec.php
@@ -7,7 +7,6 @@
 
 namespace PHPSA\Compiler\Expression\Operators;
 
-use PhpParser\Node\Name;
 use PHPSA\CompiledExpression;
 use PHPSA\Context;
 use PHPSA\Compiler\Expression;
@@ -27,11 +26,7 @@ class PostDec extends AbstractExpressionCompiler
     protected function compile($expr, Context $context)
     {
         if ($expr->var instanceof \PHPParser\Node\Expr\Variable) {
-            $variableName = $expr->var->name;
-            if ($variableName instanceof Name) {
-                $variableName = $variableName->parts[0];
-            }
-
+            $variableName = (string)$expr->var->name;
             $variable = $context->getSymbol($variableName);
             if ($variable) {
                 $variable->incUse();

--- a/src/Compiler/Expression/Operators/PostInc.php
+++ b/src/Compiler/Expression/Operators/PostInc.php
@@ -7,7 +7,6 @@
 
 namespace PHPSA\Compiler\Expression\Operators;
 
-use PhpParser\Node\Name;
 use PHPSA\CompiledExpression;
 use PHPSA\Context;
 use PHPSA\Compiler\Expression;
@@ -27,11 +26,7 @@ class PostInc extends AbstractExpressionCompiler
     protected function compile($expr, Context $context)
     {
         if ($expr->var instanceof \PHPParser\Node\Expr\Variable) {
-            $variableName = $expr->var->name;
-            if ($variableName instanceof Name) {
-                $variableName = $variableName->parts[0];
-            }
-
+            $variableName = (string)$expr->var->name;
             $variable = $context->getSymbol($variableName);
             if ($variable) {
                 $variable->incUse();

--- a/src/Compiler/Expression/Operators/PreDec.php
+++ b/src/Compiler/Expression/Operators/PreDec.php
@@ -2,7 +2,6 @@
 
 namespace PHPSA\Compiler\Expression\Operators;
 
-use PhpParser\Node\Name;
 use PHPSA\CompiledExpression;
 use PHPSA\Context;
 use PHPSA\Compiler\Expression;
@@ -22,11 +21,7 @@ class PreDec extends AbstractExpressionCompiler
     protected function compile($expr, Context $context)
     {
         if ($expr->var instanceof \PHPParser\Node\Expr\Variable) {
-            $variableName = $expr->var->name;
-            if ($variableName instanceof Name) {
-                $variableName = $variableName->parts[0];
-            }
-
+            $variableName = (string)$expr->var->name;
             $variable = $context->getSymbol($variableName);
             if ($variable) {
                 $variable->incUse();

--- a/src/Compiler/Expression/Operators/PreInc.php
+++ b/src/Compiler/Expression/Operators/PreInc.php
@@ -2,7 +2,6 @@
 
 namespace PHPSA\Compiler\Expression\Operators;
 
-use PhpParser\Node\Name;
 use PHPSA\CompiledExpression;
 use PHPSA\Context;
 use PHPSA\Compiler\Expression;
@@ -22,11 +21,7 @@ class PreInc extends AbstractExpressionCompiler
     protected function compile($expr, Context $context)
     {
         if ($expr->var instanceof \PHPParser\Node\Expr\Variable) {
-            $variableName = $expr->var->name;
-            if ($variableName instanceof Name) {
-                $variableName = $variableName->parts[0];
-            }
-
+            $variableName = (string)$expr->var->name;
             $variable = $context->getSymbol($variableName);
             if ($variable) {
                 $variable->incUse();

--- a/src/Definition/TraitDefinition.php
+++ b/src/Definition/TraitDefinition.php
@@ -83,7 +83,7 @@ class TraitDefinition extends ParentDefinition
     {
         foreach ($this->statement->stmts as $stmt) {
             if ($stmt instanceof Stmt\ClassMethod) {
-                $this->addMethod(new ClassMethod($stmt->name, $stmt, $stmt->type));
+                $this->addMethod(new ClassMethod($stmt->name, $stmt, $stmt->flags));
             }
         }
 


### PR DESCRIPTION
```php
<?php
class PhpParser\Node\Name extends NodeAbstract
{
    /**
     * @var string[] Parts of the name
     * @deprecated Avoid directly accessing $parts, use methods instead.
     */
    public $parts;
}
class PhpParser\Node\Stmt\ClassMethod extends Node\Stmt implements FunctionLike
{
    /** @deprecated Use $flags instead */
    public $type;
}
```
