### PR TITLE
Fixed #295 config path

### DIFF
--- a/src/ConfigurationLoader.php
+++ b/src/ConfigurationLoader.php
@@ -19,12 +19,11 @@ class ConfigurationLoader extends FileLoader
     public function load($resource, $type = null)
     {
         try {
-            $this->locator->locate($resource);
+            $path = $this->locator->locate($resource);
+            return Yaml::parse(file_get_contents($path));
         } catch (\InvalidArgumentException $e) {
             return [];
         }
-
-        return Yaml::parse(file_get_contents($resource));
     }
 
     /**


### PR DESCRIPTION
Find path:

1. CWD + `.phpsa.yml`
2. target + `.phpsa.yml`
3. `[]`

Find path (with `config-file` option(relative)):

1. CWD + Option (relative)
2. target + Option (relative)
3. `[]`

Find path (with `config-file` option(absolute)):

1. Option (absolute)
2. `[]`


---

It may be better to:

-   Warn of `config-file` errors.
-   Display applied `.phpsa.yml` path.

