### PR TITLE
Remove duplicate methods through inheritance

### DIFF
--- a/src/Definition/FunctionDefinition.php
+++ b/src/Definition/FunctionDefinition.php
@@ -120,14 +120,6 @@ class FunctionDefinition extends ParentDefinition
     }
 
     /**
-     * @return string
-     */
-    public function getNamespace()
-    {
-        return $this->namespace;
-    }
-
-    /**
     * @return Node\Param[]
     */
     public function getParams()

--- a/src/Definition/ParentDefinition.php
+++ b/src/Definition/ParentDefinition.php
@@ -20,22 +20,6 @@ abstract class ParentDefinition extends AbstractDefinition
     /**
      * @return string
      */
-    public function getName()
-    {
-        return $this->name;
-    }
-
-    /**
-     * @return ScopePointer
-     */
-    public function getPointer()
-    {
-        return new ScopePointer($this);
-    }
-
-    /**
-     * @return string
-     */
     public function getNamespace()
     {
         return $this->namespace;


### PR DESCRIPTION
Hey!

Type: code quality

Link to issue:

This pull request affects the following components **(please check boxes):**

* [x] Core
* [ ] Analyzer
* [ ] Compiler
* [ ] Control Flow Graph
* [ ] Documentation

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/ovr/phpsa/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

See:
https://github.com/ovr/phpsa/blob/master/src/Definition/ParentDefinition.php#L39

and:
https://github.com/ovr/phpsa/blob/master/src/Definition/AbstractDefinition.php#L37

the methods are already inherited, so we don't need them.
