### PR TITLE
Assign ref new analyzer

### DIFF
--- a/.phpsa.yml
+++ b/.phpsa.yml
@@ -1,3 +1,4 @@
+
 phpsa:
     blame:                false
 
@@ -64,6 +65,10 @@ phpsa:
 
         # Discourages the use of nested ternaries.
         nested_ternary:
+            enabled:              true
+
+        # Protection of usage & and new.
+        assign_ref_new:
             enabled:              true
 
         # Recommends the use of [] short syntax for arrays.

--- a/docs/05_Analyzers.md
+++ b/docs/05_Analyzers.md
@@ -1,3 +1,4 @@
+
 # Analyzers
 This doc gives an overview about what the different analyzers do.
 
@@ -56,6 +57,10 @@ Discourages the use of `exit()` and `die()`.
 #### nested_ternary
 
 Discourages the use of nested ternaries.
+
+#### assign_ref_new
+
+Protection of usage & and new.
 
 #### array_short_definition
 

--- a/src/Analyzer/Factory.php
+++ b/src/Analyzer/Factory.php
@@ -158,6 +158,7 @@ class Factory
             AnalyzerPass\Expression\LogicInversion::class,
             AnalyzerPass\Expression\ExitUsage::class,
             AnalyzerPass\Expression\NestedTernary::class,
+            AnalyzerPass\Expression\AssignRefNew::class,
             // Arrays
             AnalyzerPass\Expression\ArrayShortDefinition::class,
             AnalyzerPass\Expression\ArrayDuplicateKeys::class,

--- a/src/Analyzer/Pass/Expression/AssignRefNew.php
+++ b/src/Analyzer/Pass/Expression/AssignRefNew.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @author Patsura Dmitry https://github.com/ovr <talk@dmtry.me>
+ */
+
+namespace PHPSA\Analyzer\Pass\Expression;
+
+use PHPSA\Analyzer\Helper\DefaultMetadataPassTrait;
+use PHPSA\Analyzer\Pass\AnalyzerPassInterface;
+use PhpParser\Node\Expr;
+use PHPSA\Context;
+
+class AssignRefNew implements AnalyzerPassInterface
+{
+    use DefaultMetadataPassTrait {
+        DefaultMetadataPassTrait::getMetadata as defaultMetadata;
+    }
+
+    const DESCRIPTION = 'Protection of usage & and new.';
+
+    /**
+     * @param Expr\AssignRef $expr
+     * @param Context $context
+     * @return bool
+     */
+    public function pass(Expr\AssignRef $expr, Context $context)
+    {
+        if ($expr->expr instanceof Expr\New_) {
+            $context->notice(
+                'assign_ref_new',
+                'Do not use = & new, all objects in PHP are passed by reference',
+                $expr
+            );
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRegister()
+    {
+        return [
+            Expr\AssignRef::class
+        ];
+    }
+}

--- a/src/Analyzer/Pass/Statement/GlobalUsage.php
+++ b/src/Analyzer/Pass/Statement/GlobalUsage.php
@@ -27,6 +27,7 @@ class GlobalUsage implements Pass\AnalyzerPassInterface
             'Do not use globals',
             $stmt
         );
+
         return true;
     }
 

--- a/tests/analyze-fixtures/Expression/AssignRefNew.php
+++ b/tests/analyze-fixtures/Expression/AssignRefNew.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Analyze\Fixtures\Expression;
+
+class AssignRefNew
+{
+    public function testAssignRefNew()
+    {
+        $a = & new \stdClass();
+
+        return $a;
+    }
+}
+
+?>
+----------------------------
+\PHPSA\Analyzer\Pass\Expression\AssignRefNew
+----------------------------
+[
+    {
+        "type":"assign_ref_new",
+        "message":"Do not use = & new, all objects in PHP are passed by reference",
+        "file":"AssignRefNew.php",
+        "line": 8
+    }
+]


### PR DESCRIPTION
Hey!

Type: new feature

Link to issue: Sorry, from my mind 🥉 

This pull request affects the following components **(please check boxes):**

* [X] Analyzer

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [Contributing Guidelines](https://github.com/ovr/phpsa/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I wrote some tests for this PR.

Small description of change:

All objects in PHP are passed by `reference`, it's not needed to write:
But currently I support a simple way with new and object

target: (maybe someone wrote a type)

```php
$a = & new \stdClass();
```

Thanks
