### PR TITLE
Fixed false positive [missing_break_statement] with mixed comments

### DIFF
--- a/src/Analyzer/Pass/Statement/MissingBreakStatement.php
+++ b/src/Analyzer/Pass/Statement/MissingBreakStatement.php
@@ -65,23 +65,28 @@ class MissingBreakStatement implements Pass\AnalyzerPassInterface
          *         return 'the truth, or almost.';
          * }
          */
-        $stmtsCount = count($case->stmts);
-        if ($stmtsCount === 0) {
+        if ($case->stmts === null) {
             return false;
         }
 
-        $last = $case->stmts[$stmtsCount - 1];
-        if ($last instanceof Stmt\Break_ || $last instanceof Stmt\Return_
-        || $last instanceof Stmt\Throw_ || $last instanceof Stmt\Continue_) {
-            return false;
+        $stmt = end($case->stmts);
+        while ($stmt !== false) {
+            if ($stmt instanceof Stmt\Break_ || $stmt instanceof Stmt\Return_
+            || $stmt instanceof Stmt\Throw_ || $stmt instanceof Stmt\Continue_) {
+                break;
+            }
+            if (!$stmt instanceof Stmt\Nop) {
+                $context->notice(
+                    'missing_break_statement',
+                    'Missing "break" statement',
+                    $case
+                );
+
+                return true;
+            }
+            $stmt = prev($case->stmts);
         }
 
-        $context->notice(
-            'missing_break_statement',
-            'Missing "break" statement',
-            $case
-        );
-
-        return true;
+        return false;
     }
 }

--- a/src/Analyzer/Pass/Statement/MissingBreakStatement.php
+++ b/src/Analyzer/Pass/Statement/MissingBreakStatement.php
@@ -75,6 +75,7 @@ class MissingBreakStatement implements Pass\AnalyzerPassInterface
             || $stmt instanceof Stmt\Throw_ || $stmt instanceof Stmt\Continue_) {
                 break;
             }
+
             if (!$stmt instanceof Stmt\Nop) {
                 $context->notice(
                     'missing_break_statement',
@@ -84,6 +85,7 @@ class MissingBreakStatement implements Pass\AnalyzerPassInterface
 
                 return true;
             }
+
             $stmt = prev($case->stmts);
         }
 

--- a/tests/analyze-fixtures/Statement/MissingBreakStatement.php
+++ b/tests/analyze-fixtures/Statement/MissingBreakStatement.php
@@ -135,6 +135,38 @@ class MissingBreakStatement
 
         return $value;
     }
+
+    /**
+     * @return string
+     */
+    public function testValidSwitchWithComments()
+    {
+        switch (30) {
+            case 1: //< 001 comment
+            case 2:
+                $value = 'bar';
+                break;
+            // 002 comment
+            case 3:
+                {
+                    $value = 'baz';
+                    break;
+                }
+
+            /**
+             * 003 comment
+             */
+
+            case 4:
+            /*
+             * 004 comment
+             */
+            case 5:
+                $value = 'foo';
+        }
+
+        return $value;
+    }
 }
 ?>
 ----------------------------


### PR DESCRIPTION
It was detecting `case 1`, `case 2`, `case 3`, `case 4`.

```php
function testValidSwitchWithComments()
{
    switch (30) {
        case 1: //< 001 comment
        case 2:
            $value = 'bar';
            break;
        // 002 comment
        case 3:
            {
                $value = 'baz';
                break;
            }

        /**
         * 003 comment
         */

        case 4:
        /*
         * 004 comment
         */
        case 5:
            $value = 'foo';
    }

    return $value;
}
```
