### PR TITLE
Fixed #307, #311 False positive ArrayDimFetch

### DIFF
--- a/src/Analyzer/Pass/Expression/ArrayIllegalOffsetType.php
+++ b/src/Analyzer/Pass/Expression/ArrayIllegalOffsetType.php
@@ -43,8 +43,13 @@ class ArrayIllegalOffsetType implements AnalyzerPassInterface
             return false;
         }
 
-        // $array[…]
-        return $this->analyzeExpression($expr->dim, $context);
+        $var = $context->getExpressionCompiler()->compile($expr->var);
+        if ($var->isCorrectValue() && $var->isArray()) {
+            // $array[…]
+            return $this->analyzeExpression($expr->dim, $context);
+        }
+
+        return false;
     }
 
     /**

--- a/tests/analyze-fixtures/Expression/ArrayIllegalOffsetType.php
+++ b/tests/analyze-fixtures/Expression/ArrayIllegalOffsetType.php
@@ -89,14 +89,15 @@ class ArrayIllegalOffsetType
     }
 
     /**
-     * @return array
+     * @return \SplObjectStorage
      */
-    public function arrayPropertyAssignationWithObject()
+    public function arrayAssignationWithSplObjectStorage()
     {
-        $this->array = [];
+        $array = new \SplObjectStorage;
 
-        $this->array[new \DateTime()] = 'foo';
-        $this->array[] = 'bar';
+        $array[new \DateTime()] = 'foo';
+
+        return $array;
     }
 }
 ?>
@@ -139,11 +140,5 @@ PHPSA\Analyzer\Pass\Expression\ArrayIllegalOffsetType
         "message":"Illegal array offset type object for key $variable.",
         "file":"ArrayIllegalOffsetType.php",
         "line":86
-    },
-    {
-        "type":"array.illegal_offset_type",
-        "message":"Illegal array offset type object.",
-        "file":"ArrayIllegalOffsetType.php",
-        "line":97
     }
 ]


### PR DESCRIPTION
@ovr, @ddmler
- We should not emit errors to `UNIMPLEMENTED` and `UNKNOWN`.
- Possible to fetch Object on implements [ArrayAccess](http://php.net/manual/class.arrayaccess.php) interface(e.g. SplDoublyLinkedList[mixed], SplFixedArray[int], SplObjectStorage[object], ArrayObject[mixed]).
- The type of the array subscript can also be an object by ArrayAccess.
- return null for scalar other than string.
