### PR TITLE
[Analyzer] Deprecate png2wbmp and jpeg2wbmp

### DIFF
--- a/src/Analyzer/Pass/Expression/FunctionCall/DeprecatedFunctions.php
+++ b/src/Analyzer/Pass/Expression/FunctionCall/DeprecatedFunctions.php
@@ -27,6 +27,8 @@ class DeprecatedFunctions extends AbstractFunctionCallAnalyzer
         'gmp_random' => ['7.2','_'],
         'each' => ['7.2','_'],
         'create_function' => ['7.2','_'],
+        'jpeg2wbmp' => ['7.2','_'],
+        'png2wbmp' => ['7.2','_'],
     ];
 
     public function pass(FuncCall $funcCall, Context $context)


### PR DESCRIPTION
Hey!

Type: new feature

Link to issue:

This pull request affects the following components **(please check boxes):**

* [ ] Core
* [x] Analyzer
* [ ] Compiler
* [ ] Control Flow Graph
* [ ] Documentation

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/ovr/phpsa/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Adds 2 functions that are deprecated as of PHP 7.2

Thanks
