### PR TITLE
Var duplicate in Closure use statement

### DIFF
--- a/.phpsa.yml
+++ b/.phpsa.yml
@@ -84,6 +84,10 @@ phpsa:
         array_illegal_offset_type:
             enabled:              true
 
+        # Check for duplicate variables in use statement
+        duplicated_variables_in_use_closure:
+            enabled:              true
+
         # Checks for use of alias functions and suggests the use of the originals.
         alias_check:
             enabled:              true

--- a/docs/05_Analyzers.md
+++ b/docs/05_Analyzers.md
@@ -75,6 +75,10 @@ one will be used as all others are overwritten.
 
 Checks for illegal array key types (for example objects).
 
+#### duplicated_variables_in_use_closure
+
+Check for duplicate variables in use statement
+
 #### alias_check
 
 Checks for use of alias functions and suggests the use of the originals.

--- a/src/Analyzer/Factory.php
+++ b/src/Analyzer/Factory.php
@@ -87,7 +87,7 @@ class Factory
 
         $instanciate = function ($passClass) use ($analyzersConfig) {
             $passName = $passClass::getMetadata()->getName();
-            
+
             return new $passClass($analyzersConfig[$passName]);
         };
 
@@ -163,6 +163,8 @@ class Factory
             AnalyzerPass\Expression\ArrayShortDefinition::class,
             AnalyzerPass\Expression\ArrayDuplicateKeys::class,
             AnalyzerPass\Expression\ArrayIllegalOffsetType::class,
+            // Closures
+            AnalyzerPass\Expression\DuplicatedVariablesInUseClosure::class,
             // Function call
             AnalyzerPass\Expression\FunctionCall\AliasCheck::class,
             AnalyzerPass\Expression\FunctionCall\DebugCode::class,

--- a/src/Analyzer/Pass/Expression/DuplicatedVariablesInUseClosure.php
+++ b/src/Analyzer/Pass/Expression/DuplicatedVariablesInUseClosure.php
@@ -17,7 +17,7 @@ class DuplicatedVariablesInUseClosure implements AnalyzerPassInterface
     const DESCRIPTION = 'Check for duplicate variables in use statement';
 
     /**
-     * @param Closure $funcCall
+     * @param Closure $expr
      * @param Context $context
      * @return bool
      */

--- a/src/Analyzer/Pass/Expression/DuplicatedVariablesInUseClosure.php
+++ b/src/Analyzer/Pass/Expression/DuplicatedVariablesInUseClosure.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @author Strahinja Djuric https://github.com/kilgaloon <radju22@gmail.com>
+ */
+namespace PHPSA\Analyzer\Pass\Expression;
+
+use PHPSA\Context;
+use PHPSA\Analyzer\Pass;
+use PhpParser\Node\Expr\Closure;
+use PHPSA\Analyzer\Pass\AnalyzerPassInterface;
+use PHPSA\Analyzer\Helper\DefaultMetadataPassTrait;
+
+class DuplicatedVariablesInUseClosure implements AnalyzerPassInterface
+{
+    use DefaultMetadataPassTrait;
+
+    const DESCRIPTION = 'Check for duplicate variables in use statement';
+
+    /**
+     * @param Closure $funcCall
+     * @param Context $context
+     * @return bool
+     */
+    public function pass(Closure $expr, Context $context)
+    {
+        $varUsed = [];
+        foreach ($expr->uses as $use) {
+            $var = $context->getExpressionCompiler()->compile($use->var);
+            if (in_array($var->getValue(), $varUsed)) {
+                $context->notice(
+                    'duplicated_variable_in_use_closure',
+                    sprintf("Duplicated variable $%s in use statement.", $use->var),
+                    $expr
+                );
+
+                return false;
+            } else {
+                array_push($varUsed, $use->var);
+            }
+        }
+
+        return true;
+    }
+
+    public function getRegister()
+    {
+        return [
+            Closure::class
+        ];
+    }
+}

--- a/tests/analyze-fixtures/Expression/DuplicatedVariablesInUseClosure.php
+++ b/tests/analyze-fixtures/Expression/DuplicatedVariablesInUseClosure.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Analyze\Fixtures\Expression;
+
+class DuplicatedVariablesInUseClosure
+{
+    /**
+     * @return string
+     */
+    public function useValid()
+    {
+        function () use ($a, $b, $c) {
+
+        };
+    }
+
+    /**
+     * @return string
+     */
+    public function useInvalid()
+    {
+        function () use ($a, $b, $c, $a) {
+
+        };
+    }
+
+}
+
+?>
+----------------------------
+PHPSA\Analyzer\Pass\Expression\DuplicatedVariablesInUseClosure
+----------------------------
+[
+    {
+        "type":"duplicated_variable_in_use_closure",
+        "message":"Duplicated variable $a in use statement.",
+        "file":"DuplicatedVariablesInUseClosure.php",
+        "line":21
+    }
+]


### PR DESCRIPTION
Hey!

Type: new feature

Link to issue: #279

This pull request affects the following components **(please check boxes):**

* [ ] Core
* [x] Analyzer
* [ ] Compiler
* [ ] Control Flow Graph
* [ ] Documentation

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/ovr/phpsa/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:
Detecting duplicated usage of variables passed to Closure use statement

Thanks
